### PR TITLE
feat: add marketplace generator with GitHub Actions auto-regen

### DIFF
--- a/.github/workflows/generate-marketplace.yml
+++ b/.github/workflows/generate-marketplace.yml
@@ -1,0 +1,25 @@
+name: Generate Marketplace
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate marketplace data
+        run: python3 scripts/make_marketplace.py
+
+      - name: Commit generated files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/marketplace.json '.claude/skills/*/.claude-plugin/plugin.json'
+          git diff --cached --quiet || git commit -m "chore: regenerate marketplace data [skip ci]"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,9 @@ tmp/
 temp/
 *.tmp
 
-# Claude plugin artifacts
-.claude-plugin/
+# Claude plugin temp files only (marketplace.json and plugin.json are committed via CI)
+.claude-plugin/*.tmp
+.claude/skills/*/.claude-plugin/*.tmp
 
 # Private portfolio site (submodule)
 erichowens_com/

--- a/scripts/make_marketplace.py
+++ b/scripts/make_marketplace.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Generate .claude-plugin/marketplace.json and per-skill plugin.json files."""
+
+import json
+import os
+import re
+
+SKILLS_DIR = ".claude/skills"
+MARKETPLACE_NAME = "some-claude-skills"
+OWNER = {"name": "Erich Owens", "url": "https://www.erichowens.com"}
+def extract_frontmatter(text):
+    """Extract YAML frontmatter between --- delimiters without PyYAML."""
+    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        return {}
+    raw = match.group(1)
+    result = {}
+    lines = raw.split("\n")
+    current_key = None
+    current_val_lines = []
+
+    def flush():
+        if current_key:
+            val = " ".join(current_val_lines).strip()
+            result[current_key] = val
+
+    for line in lines:
+        kv = re.match(r"^(\w[\w-]*):\s*(.*)", line)
+        if kv:
+            flush()
+            current_key = kv.group(1)
+            current_val_lines = [kv.group(2)]
+        elif current_key and line.startswith(" "):
+            current_val_lines.append(line.strip())
+
+    flush()
+    return result
+
+
+plugins = []
+skipped = []
+
+skill_names = sorted(os.listdir(SKILLS_DIR))
+for skill_name in skill_names:
+    skill_path = os.path.join(SKILLS_DIR, skill_name)
+    if not os.path.isdir(skill_path):
+        continue
+
+    skill_md = os.path.join(skill_path, "SKILL.md")
+    if not os.path.exists(skill_md):
+        if os.path.exists(os.path.join(skill_path, "DEPRECATED.md")):
+            skipped.append((skill_name, "deprecated"))
+        else:
+            skipped.append((skill_name, "no SKILL.md"))
+        continue
+
+    with open(skill_md) as f:
+        content = f.read()
+
+    fm = extract_frontmatter(content)
+    name = fm.get("name", skill_name)
+    description = fm.get("description", "")
+
+    plugin_name = re.sub(r"[^a-z0-9-]", "-", name.lower()).strip("-")
+
+    plugin_dir = os.path.join(skill_path, ".claude-plugin")
+    os.makedirs(plugin_dir, exist_ok=True)
+    plugin_json = {"name": plugin_name, "description": description}
+    with open(os.path.join(plugin_dir, "plugin.json"), "w") as f:
+        json.dump(plugin_json, f, indent=2)
+        f.write("\n")
+
+    plugins.append({
+        "name": plugin_name,
+        "source": f"./{SKILLS_DIR}/{skill_name}",
+        "description": description,
+    })
+
+os.makedirs(".claude-plugin", exist_ok=True)
+
+marketplace = {
+    "name": MARKETPLACE_NAME,
+    "description": "A curated collection of 190+ Claude Code skills covering AI engineering, design, frontend, backend, DevOps, product, and creative domains.",
+    "owner": OWNER,
+    "plugins": plugins,
+}
+
+with open(".claude-plugin/marketplace.json", "w") as f:
+    json.dump(marketplace, f, indent=2)
+    f.write("\n")
+
+print(f"Done: {len(plugins)} plugins added to marketplace.json")
+if skipped:
+    print(f"Skipped {len(skipped)}: {skipped[:5]}{'...' if len(skipped) > 5 else ''}")


### PR DESCRIPTION
## Hey Erich 👋

Really enjoying what you've built here — great curation and the Win 3.1 aesthetic is chef's kiss.

---

## Problem

When trying to install the skills via the Claude marketplace, it wasn't working properly because the `plugin.json` files were missing from the skill folders. The `.claude-plugin/` directory was fully gitignored so none of the manifest files were tracked.

Rather than generating them one by one manually, I wrote a small generator that handles all of them at once and wires it into CI so they stay in sync automatically.

## What's included

**`scripts/make_marketplace.py`** — zero-dependency Python script (stdlib only, no PyYAML) that generates:
- `.claude-plugin/marketplace.json` — top-level marketplace manifest for all 195+ skills
- `.claude/skills/*/.claude-plugin/plugin.json` — one per skill, derived from `SKILL.md` frontmatter

**`.github/workflows/generate-marketplace.yml`** — runs the generator on every push to `main` and commits the output back via `github-actions[bot]` with `[skip ci]` to avoid infinite loops.

**`.gitignore`** — updated to track the generated JSON files instead of ignoring the whole `.claude-plugin/` directory.

## Tested locally

```
Done: 195 plugins added to marketplace.json
Skipped 1: [('.archive', 'no SKILL.md')]
```