### PR TITLE
MS Paint: mobile fix + free Cloudflare tier, usage tracking, expertise-accrual & vision agents

### DIFF
--- a/website-next/MSPAINT_BACKEND.md
+++ b/website-next/MSPAINT_BACKEND.md
@@ -194,3 +194,50 @@ website-next/
    ├─ mspaint/PromptInput/PromptInput.*  remaining-uses badge
    └─ desktop/MSPaintAppContent.tsx      quota fetch + output snapshot upload
 ```
+
+## Vision, references, look-as-you-go, critique & replays
+
+Vision runs on the multimodal models in the catalog (Kimi K2.7, Llama 4 Scout —
+marked 👁). Three optional capabilities:
+
+- **Look at references first** — fetches a reference photo (Pexels;
+  `PEXELS_API_KEY`) and shows it to the vision model before it plans/draws.
+- **Look as you go / "another turn"** — the draw protocol lets the agent set
+  `"needsAnotherTurn": true` so it doesn't quit early with a sparse picture. The
+  client renders the partial canvas and a vision model sees it and continues,
+  up to a turn cap. (Server can't rasterize, so this round-trips through the
+  browser by design.)
+- **Critique its own result** — after the final render, a vision model SEES the
+  image, scores it 1–5, and the elicited lesson is accrued (`saw_image = 1`).
+
+### Who gets what
+
+- **Public visitors:** controlled by admin feature flags (the "What the public
+  gets" panel on `/api/admin`, stored in `config.public_features`). Honored by
+  `/api/mspaint/generate` + `/api/mspaint/continue` + `/api/mspaint/critique`.
+- **You (admin):** the batch console (`/api/admin/batch`) is unrestricted — any
+  model, references/critique toggles, and a max-turns dial — ideal for high-cost
+  "training" runs that accrue lessons fast.
+
+### Replays
+
+Every step is logged to `gen_events` (assess → search → look → plan → draw ×N →
+critique). `/api/admin/replay?id=<generationId>` plays the whole agentic process
+back: the reference photos it looked at, its plan, each draw turn rendered
+cumulatively on a canvas, and the final critique/score. Click any drawing in the
+gallery or batch grid to open its replay.
+
+### New endpoints
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/admin/flags` | GET/POST | read/set public feature flags |
+| `/api/admin/run` | POST | one batch draw pass (references/reflect options) |
+| `/api/admin/continue` | POST | a continuation/look-as-you-go turn (vision) |
+| `/api/admin/critique` | POST | vision critique of a render → lesson + score |
+| `/api/admin/replay?id=` | GET | step-by-step replay viewer |
+| `/api/mspaint/continue` | POST | public look-as-you-go (flag-gated) |
+| `/api/mspaint/critique` | POST | public vision critique (flag-gated) |
+
+Note: references require `PEXELS_API_KEY`; all vision features require the active
+free-tier model to be vision-capable (Kimi / Llama 4 Scout).

--- a/website-next/MSPAINT_BACKEND.md
+++ b/website-next/MSPAINT_BACKEND.md
@@ -1,0 +1,146 @@
+# MS Paint — Free Tier, Usage Tracking & Expertise Accrual
+
+This documents the backend added to the OS2 MS Paint app: a free AI-drawing
+tier powered by Cloudflare Workers AI, per-visitor usage limits, full logging
+of every drawing, an admin gallery, and an expertise-accrual loop built on
+cognitive task analysis.
+
+## TL;DR of what changed
+
+- **Mobile drawing fixed.** The canvas now uses Pointer Events (mouse + touch +
+  pen), pointer capture, screen→canvas coordinate scaling, and `touch-action:
+  none`. Taps and drags register correctly on phones.
+- **5 free drawings per visitor** via a cheap Cloudflare model
+  (`@cf/meta/llama-3.1-8b-instruct`), emitting the same paint-command JSON so the
+  drawing animation is identical.
+- **Bring-your-own Anthropic key = unlimited** (and not counted).
+- **Remaining uses shown** in the prompt bar (`3 / 5 free left`).
+- **Everything is logged** (D1 + R2): prompt, plan, commands, before/after PNGs,
+  model, tokens, latency, and an accrued "lesson".
+- **Admin gallery** at `/api/admin` (token-gated) to browse all of it.
+
+## Architecture
+
+```
+Browser (MSPaintAppContent)
+  │  GET  /api/mspaint/usage      → remaining free uses (on load)
+  │  POST /api/mspaint/generate   → { commands, usesRemaining, generationId }
+  │  POST /api/mspaint/snapshot   → final rendered PNG (the "output")
+  ▼
+Cloudflare Pages Functions (functions/)
+  ├─ identify()        cookie UUID + sha256(ip+ua+salt) backup   [_lib/identity.ts]
+  ├─ quota (D1)        users.free_uses_used vs FREE_USES_LIMIT   [_lib/db.ts]
+  ├─ assess (AI)       classify prompt → category + tools        [_lib/workers-ai.ts]
+  ├─ recall (D1)       top lessons for category → inject          [_lib/db.ts]
+  ├─ draw              Workers AI (free) | Anthropic (own key)    [generate.ts]
+  ├─ log (D1 + R2)     generations row + before/after PNGs        [_lib/db.ts,_lib/r2.ts]
+  └─ reflect (AI)      Cognitive Demands Table → lessons row      [waitUntil]
+```
+
+### The expertise-accrual loop (why it's shaped this way)
+
+Per the linked cognitive-task-analysis skills (ACTA, Critical Decision Method,
+ShadowBox), the agent doesn't just emit commands — it runs a small expertise
+loop, and every drawing by anyone accrues reusable knowledge:
+
+1. **Situation assessment** (ACTA pattern recognition): classify the prompt into
+   a category + the tools that matter.
+2. **Wisdom recall** (ShadowBox): the best prior `lessons` for that category are
+   injected into the system prompt as "Lessons from artists past."
+3. **Mental simulation**: the agent must emit an explicit `plan` before commands.
+4. **Knowledge elicitation** (Cognitive Demands Table + Knowledge Audit): a
+   reflection pass fills `difficult_element / why_difficult / common_errors /
+   cues_and_strategies / what_worked / do_differently / …`, stored in `lessons`.
+5. That lesson becomes step-2 wisdom for the next agent. The flywheel turns.
+
+The `lessons` table is literally a Cognitive Demands Table — the corpus you can
+mine later to author "official" MS Paint wisdom or fine-tune a model.
+
+## Resources (already provisioned)
+
+| Kind | Name | ID |
+|------|------|----|
+| D1   | `someclaudeskills-mspaint` | `2576030c-1019-41df-87c5-1016ef9af4cf` |
+| R2   | `someclaudeskills-mspaint` | — |
+
+Schema is in `schema.sql` and has already been applied to the D1 database.
+To re-apply (idempotent):
+
+```bash
+npx wrangler d1 execute someclaudeskills-mspaint --remote --file=./schema.sql
+```
+
+## Remaining steps to go live
+
+Bindings are declared in `wrangler.toml`. Two things still require your account:
+
+### 1. Attach bindings to the Pages project
+
+- If the project deploys via `wrangler pages deploy`, `wrangler.toml` is used
+  directly — nothing else to do.
+- If it deploys via the **Pages Git integration**, confirm `name` in
+  `wrangler.toml` matches the Pages project name, OR add the same bindings in
+  the dashboard → your Pages project → **Settings → Functions → Bindings**:
+  - Workers AI: variable `AI`
+  - D1: variable `MSPAINT_DB` → `someclaudeskills-mspaint`
+  - R2: variable `MSPAINT_BUCKET` → `someclaudeskills-mspaint`
+
+### 2. Set secrets
+
+```bash
+# Required for the admin gallery
+npx wrangler pages secret put ADMIN_TOKEN
+
+# Strongly recommended (salts the IP/UA hash so it can't be reversed)
+npx wrangler pages secret put IDENTITY_SALT
+
+# Optional: fallback drawing key + reference images
+npx wrangler pages secret put ANTHROPIC_API_KEY
+npx wrangler pages secret put PEXELS_API_KEY
+```
+
+Tunable vars (in `wrangler.toml`): `FREE_USES_LIMIT` (default 5),
+`CF_TEXT_MODEL` (default `@cf/meta/llama-3.1-8b-instruct`).
+
+## Admin gallery (Erich-only)
+
+Token-gated. Pass `?token=<ADMIN_TOKEN>` (or header `X-Admin-Token`).
+
+| Route | Returns |
+|-------|---------|
+| `/api/admin?token=…` | HTML gallery of all drawings + lessons + stats |
+| `/api/admin/data?token=…&limit=&offset=` | JSON of generations |
+| `/api/admin/stats?token=…` | aggregate stats + per-category counts |
+| `/api/admin/image?token=…&key=…` | streams a drawing PNG from R2 |
+
+R2 is private; images are only served through the token-gated `image` route.
+
+## Identity & privacy
+
+- **MAC addresses are not used** — browsers never expose them to web servers.
+- Identity = first-party anonymous cookie UUID (primary) + `sha256(ip + ua +
+  salt)` (backup, so clearing cookies / incognito doesn't trivially reset the
+  count). The raw IP is never stored, only its salted hash.
+- **Free-tier drawings are logged** (prompt, plan, commands, before/after PNGs).
+  Because you're logging visitor-submitted content, add a short line to your
+  privacy policy and, for GDPR/CCPA, ideally a one-time notice. The Settings
+  window already discloses this in-app. A bring-your-own-key user's API key is
+  never logged.
+
+## Files
+
+```
+website-next/
+├─ wrangler.toml                         bindings + vars
+├─ schema.sql                            D1 schema (CDT/Knowledge-Audit shaped)
+├─ functions/
+│  ├─ tsconfig.json
+│  ├─ _lib/{env,identity,db,r2,cta,workers-ai}.ts
+│  └─ api/
+│     ├─ mspaint/{generate,usage,snapshot}.ts
+│     └─ admin/[[path]].ts               token-gated gallery
+└─ src/components/
+   ├─ mspaint/Canvas/Canvas.tsx          pointer-event (mobile) fix
+   ├─ mspaint/PromptInput/PromptInput.*  remaining-uses badge
+   └─ desktop/MSPaintAppContent.tsx      quota fetch + output snapshot upload
+```

--- a/website-next/MSPAINT_BACKEND.md
+++ b/website-next/MSPAINT_BACKEND.md
@@ -106,12 +106,30 @@ Tunable vars (in `wrangler.toml`): `FREE_USES_LIMIT` (default 5),
 
 Token-gated. Pass `?token=<ADMIN_TOKEN>` (or header `X-Admin-Token`).
 
-| Route | Returns |
-|-------|---------|
-| `/api/admin?token=…` | HTML gallery of all drawings + lessons + stats |
-| `/api/admin/data?token=…&limit=&offset=` | JSON of generations |
-| `/api/admin/stats?token=…` | aggregate stats + per-category counts |
-| `/api/admin/image?token=…&key=…` | streams a drawing PNG from R2 |
+| Route | Method | Returns |
+|-------|--------|---------|
+| `/api/admin?token=…` | GET | HTML gallery + **model picker** + lessons + stats |
+| `/api/admin/data?token=…&limit=&offset=` | GET | JSON of generations |
+| `/api/admin/stats?token=…` | GET | aggregate stats + per-category counts |
+| `/api/admin/models?token=…` | GET | model catalog + currently-active model (JSON) |
+| `/api/admin/model?token=…` | POST | set the active free-tier model (`{model}` JSON or form) |
+| `/api/admin/image?token=…&key=…` | GET | streams a drawing PNG from R2 |
+
+### Choosing the drawing model (with prices)
+
+The gallery shows the **currently-active model** in the header and a price table
+you pick from (Cloudflare per-token pricing + an estimated `$/drawing`). The
+catalog lives in `functions/_lib/models.ts`. The selection is stored in D1
+(`config.cf_text_model`) and read at request time, so it changes live with no
+redeploy. Each drawing card also shows which model produced it.
+
+Notes:
+- The picker controls the **free-tier drawing** model only. Classification and
+  the reflection pass always use the cheap recommended model to keep costs flat.
+- Bring-your-own-key (Anthropic) users are unaffected.
+- Default is `@cf/qwen/qwen3-30b-a3b-fp8` (best value: reliable JSON, ~3B-tier
+  price). Cheapest is `@cf/meta/llama-3.1-8b-instruct-fp8-fast`; most capable is
+  `@cf/meta/llama-3.3-70b-instruct-fp8-fast` (~6× the cost).
 
 R2 is private; images are only served through the token-gated `image` route.
 

--- a/website-next/MSPAINT_BACKEND.md
+++ b/website-next/MSPAINT_BACKEND.md
@@ -109,11 +109,36 @@ Token-gated. Pass `?token=<ADMIN_TOKEN>` (or header `X-Admin-Token`).
 | Route | Method | Returns |
 |-------|--------|---------|
 | `/api/admin?token=…` | GET | HTML gallery + **model picker** + lessons + stats |
+| `/api/admin/batch?token=…` | GET | **Batch console** — run a model N× and watch wisdom accrue live |
+| `/api/admin/wisdom?token=…` | GET | **Wisdom explorer** — loop diagram + Cognitive Demands Table + Knowledge Audit + the exact injected text |
 | `/api/admin/data?token=…&limit=&offset=` | GET | JSON of generations |
 | `/api/admin/stats?token=…` | GET | aggregate stats + per-category counts |
 | `/api/admin/models?token=…` | GET | model catalog + currently-active model (JSON) |
 | `/api/admin/model?token=…` | POST | set the active free-tier model (`{model}` JSON or form) |
+| `/api/admin/run?token=…` | POST | run ONE drawing (the batch unit): `{model, prompt, batchId, index, total}` |
 | `/api/admin/image?token=…&key=…` | GET | streams a drawing PNG from R2 |
+
+### Batch console (soak test)
+
+`/api/admin/batch` runs a chosen model on one prompt N times (default 100),
+**driven from the browser** so it never hits a Worker time limit. Each iteration
+goes through the full loop (assess → recall wisdom → draw → reflect → accrue),
+renders the result to a canvas (and uploads it so it shows in the gallery), and
+updates live metrics: parse-success rate, avg commands, avg latency, estimated
+spend, and lessons accrued. A side panel shows **exactly the "Lessons from
+artists past" text the agent saw** that iteration — so you can literally watch
+the wisdom pool grow and feed back in.
+
+### Wisdom explorer
+
+`/api/admin/wisdom` makes the accrual loop legible:
+- a **diagram** of the 5 stages with the wisdom-injection step highlighted,
+  spelling out **when** (step 2, before drawing), **how much** (top 4 by
+  helpfulness then recency), and **where it comes from** (step 5 of every prior
+  drawing);
+- the **exact injected block** an agent drawing a given category sees right now;
+- the **Cognitive Demands Table** (difficult element / why / common errors /
+  cues & strategies) and the **Knowledge Audit** cards, per category.
 
 ### Choosing the drawing model (with prices)
 
@@ -128,8 +153,15 @@ Notes:
   the reflection pass always use the cheap recommended model to keep costs flat.
 - Bring-your-own-key (Anthropic) users are unaffected.
 - Default is `@cf/qwen/qwen3-30b-a3b-fp8` (best value: reliable JSON, ~3B-tier
-  price). Cheapest is `@cf/meta/llama-3.1-8b-instruct-fp8-fast`; most capable is
-  `@cf/meta/llama-3.3-70b-instruct-fp8-fast` (~6× the cost).
+  price).
+- **Best:** `@cf/moonshotai/kimi-k2.7-code` (frontier 1T MoE, 262K ctx, native
+  structured JSON) — priciest output ($4/M). `@cf/openai/gpt-oss-120b` is the
+  best *value* flagship ($0.35/$0.75). Also strong: Llama 4 Scout, QwQ-32B.
+- **Worst:** `@cf/meta/llama-3.2-1b` (cheapest, frequently malformed JSON — a
+  good baseline) and `@cf/meta/llama-2-7b-chat-fp16` (a trap: ancient *and* the
+  most expensive output on the platform).
+- gpt-oss models use Cloudflare's Responses API (`instructions`/`input`); the
+  client transparently handles that — everything else uses chat `messages`.
 
 R2 is private; images are only served through the token-gated `image` route.
 

--- a/website-next/functions/_lib/cta.ts
+++ b/website-next/functions/_lib/cta.ts
@@ -147,6 +147,12 @@ export function buildCritiqueUserContent(prompt: string, commandCount: number): 
  */
 export const REFLECTION_SYSTEM_PROMPT = `You are a drawing coach running a cognitive task analysis on an MS Paint AI agent that just finished a drawing. Elicit transferable expertise.
 
+When the agent's own reasoning trace (its concurrent think-aloud, captured WHILE
+it drew) is provided below, treat it as primary evidence: DISTILL the real
+strategy, struggle, and decision points it reveals — do not invent a plausible
+rationale. A concurrent trace is far more reliable than a guess reconstructed
+after the fact. If no trace is provided, infer carefully from the result.
+
 Return ONLY this JSON object:
 {
   "difficultElement": "the single most cognitively demanding part of drawing this subject",
@@ -161,19 +167,34 @@ Return ONLY this JSON object:
 }
 Be specific and reusable — another agent drawing the same category should be able to act on cuesAndStrategies and doDifferently.`;
 
-/** Build the reflection user message from the drawing result. */
+/** Build the reflection user message from the drawing result.
+ *
+ * `reasoning` is the draw agent's concurrent chain-of-thought (from a reasoning
+ * model's <think> trace or reasoning field). When present it anchors the
+ * cognitive task analysis in what the agent actually thought, rather than a
+ * post-hoc reconstruction. `thinking` is the shorter rationale the agent wrote
+ * into its own JSON output.
+ */
 export function buildReflectionUserContent(
   prompt: string,
   category: string | null,
   description: string | null,
-  commandCount: number
+  commandCount: number,
+  reasoning?: string | null,
+  thinking?: string | null
 ): string {
+  const trace = (reasoning || thinking || "").trim();
+  // Cap the trace so a long reasoning dump can't blow the reflection budget.
+  const traceBlock = trace
+    ? `\n\nAgent's concurrent reasoning trace (think-aloud while drawing):\n"""\n${trace.slice(0, 6000)}\n"""`
+    : "\n\n(No reasoning trace was captured for this drawing.)";
+
   return `Prompt: "${prompt}"
 Category: ${category || "general"}
 Agent's description of result: ${description || "(none)"}
-Commands emitted: ${commandCount}
+Commands emitted: ${commandCount}${traceBlock}
 
-Produce the cognitive task analysis JSON now.`;
+Produce the cognitive task analysis JSON now${trace ? ", grounded in the trace above" : ""}.`;
 }
 
 /** Extract the first balanced JSON object from a model's text output. */

--- a/website-next/functions/_lib/cta.ts
+++ b/website-next/functions/_lib/cta.ts
@@ -69,13 +69,75 @@ ${renderWisdom(wisdom)}
 3. Use filled shapes for masses; use lines/curves for contours; use spray for texture/shading.
 4. Keep everything inside the 640x480 canvas.
 
+## Finishing the job (important)
+Do NOT stop early with a sparse, unfinished drawing. If you would run out of
+room before the picture is complete, draw as much as you can THIS turn and set
+"needsAnotherTurn": true — you will be shown the current canvas and may continue.
+Only set it to false when the drawing is genuinely complete.
+
 ## Response format — return ONLY this JSON object, no prose around it:
 {
   "thinking": "your artistic reasoning",
   "plan": ["ordered steps you will take, e.g. 'sky gradient', 'mountain silhouette', 'sun'"],
   "description": "one short sentence describing the result",
+  "needsAnotherTurn": false,
   "commands": [ ...paint commands... ]
 }`;
+}
+
+/**
+ * System prompt for a CONTINUATION turn (look-as-you-go). The agent is shown
+ * the current canvas image and adds more commands without clearing.
+ */
+export function buildContinuePrompt(wisdom: Wisdom[]): string {
+  return `You are an expert artist continuing an in-progress MS Paint drawing.
+
+${PAINT_COMMAND_SPEC}
+${renderWisdom(wisdom)}
+
+You are shown the CURRENT canvas. Add MORE commands to push it toward the goal:
+fill empty areas, add missing elements, refine details and shading. Do NOT emit
+clearCanvas. Keep going until the picture is complete; set "needsAnotherTurn":
+true if you still need another turn after this one.
+
+Return ONLY this JSON object:
+{
+  "thinking": "what's missing and what you'll add",
+  "description": "what you added",
+  "needsAnotherTurn": false,
+  "commands": [ ...more paint commands... ]
+}`;
+}
+
+/** Build the user message for a continuation turn. */
+export function buildContinueUserContent(prompt: string, pass: number): string {
+  return `Goal: "${prompt}". This is continuation turn ${pass}. The image above is the canvas so far. Add what's missing.`;
+}
+
+/**
+ * Vision critique — the model SEES the rendered drawing and elicits a
+ * Cognitive Demands Table + Knowledge Audit grounded in what it actually looks
+ * like, plus a 1-5 aesthetic score.
+ */
+export const CRITIQUE_VISION_SYSTEM = `You are a drawing coach. You are shown the FINISHED MS Paint drawing (image) an AI agent made for a prompt. Judge what you actually see and elicit transferable expertise.
+
+Return ONLY this JSON object:
+{
+  "aestheticScore": 3.5,
+  "difficultElement": "the most cognitively demanding part of this subject",
+  "whyDifficult": "why it's hard in MS Paint",
+  "commonErrors": "the typical mistake (point to what you see in this image)",
+  "cuesAndStrategies": "the concrete technique an expert uses, specific to the command set",
+  "whatWorked": ["1-3 things that actually look good"],
+  "whatDidnt": ["1-3 things that look wrong/incomplete in the image"],
+  "wishIKnew": "one thing that would have helped before starting",
+  "doDifferently": "the single highest-leverage change next time",
+  "toolsNeeded": ["paint commands most central to this subject"]
+}
+aestheticScore is 1.0 (awful) to 5.0 (excellent). Be honest and specific to THIS image.`;
+
+export function buildCritiqueUserContent(prompt: string, commandCount: number): string {
+  return `The drawing above was made for the prompt: "${prompt}" using ${commandCount} paint commands. Critique what you see and return the JSON.`;
 }
 
 /**

--- a/website-next/functions/_lib/cta.ts
+++ b/website-next/functions/_lib/cta.ts
@@ -1,0 +1,126 @@
+/**
+ * Cognitive Task Analysis scaffolding for the drawing agent.
+ * ==========================================================
+ * The free-tier agent doesn't just "emit commands". It runs a small
+ * expertise loop drawn from Applied Cognitive Task Analysis (ACTA),
+ * the Critical Decision Method, and ShadowBox:
+ *
+ *   1. Situation assessment  — what kind of thing is this, which tools matter
+ *      (handled by the classifier in generate.ts).
+ *   2. Wisdom recall         — accrued lessons for this category are injected
+ *      below as "Lessons from artists past" (ShadowBox: compare against the
+ *      decisions of prior experts).
+ *   3. Mental simulation     — the agent must produce an explicit `plan`
+ *      before committing to commands.
+ *   4. Knowledge elicitation — after drawing, a reflection pass fills a
+ *      Cognitive Demands Table + Knowledge Audit, which is stored and becomes
+ *      step-2 wisdom for the next agent. This is the accrual flywheel.
+ */
+
+import type { Wisdom } from "./db";
+
+/** The drawing-command vocabulary (the agent's formal tools). */
+export const PAINT_COMMAND_SPEC = `## Canvas
+- Size: 640 x 480 pixels. Origin (0,0) top-left. X right, Y down. Background starts white (#FFFFFF).
+
+## Palette (use ONLY these)
+Dark:  #000000 #808080 #800000 #808000 #008000 #008080 #000080 #800080 #008B8B #556B2F #8B4513 #483D8B #4B0082 #191970
+Light: #FFFFFF #C0C0C0 #FF0000 #FFFF00 #00FF00 #00FFFF #0000FF #FF00FF #FFA500 #FFC0CB #ADD8E6 #90EE90 #E6E6FA #FFDAB9
+
+## Commands (formal tools)
+Color:  {"type":"setForegroundColor","color":"#RRGGBB"}  {"type":"setBackgroundColor","color":"#RRGGBB"}
+Draw:   {"type":"drawPixel","x":N,"y":N}  {"type":"drawLine","x1":N,"y1":N,"x2":N,"y2":N}
+        {"type":"drawFreehand","points":[{"x":N,"y":N},...]}
+        {"type":"drawCurve","startX":N,"startY":N,"endX":N,"endY":N,"controlX1":N,"controlY1":N}
+Shape:  {"type":"drawRectangle","x":N,"y":N,"width":N,"height":N,"fillMode":"outline|filled|both"}
+        {"type":"drawEllipse","x":N,"y":N,"width":N,"height":N,"fillMode":"..."}
+        {"type":"drawRoundedRectangle","x":N,"y":N,"width":N,"height":N,"radius":N,"fillMode":"..."}
+        {"type":"drawPolygon","points":[{"x":N,"y":N},...],"fillMode":"..."}
+Other:  {"type":"floodFill","x":N,"y":N}  {"type":"spray","x":N,"y":N}  {"type":"sprayPath","points":[...]}
+        {"type":"placeText","x":N,"y":N,"text":"...","fontSize":N,"bold":bool}
+        {"type":"clearCanvas"}`;
+
+/** Render accrued lessons as a ShadowBox-style briefing for the agent. */
+export function renderWisdom(wisdom: Wisdom[]): string {
+  if (!wisdom.length) return "";
+  const lines = wisdom
+    .map((w, i) => {
+      const parts: string[] = [];
+      if (w.difficultElement) parts.push(`hard part: ${w.difficultElement}`);
+      if (w.cuesAndStrategies) parts.push(`what works: ${w.cuesAndStrategies}`);
+      if (w.doDifferently) parts.push(`do differently: ${w.doDifferently}`);
+      return parts.length ? `${i + 1}. ${parts.join(" — ")}` : "";
+    })
+    .filter(Boolean);
+  if (!lines.length) return "";
+  return `\n\n## Lessons from artists past (apply these)\nPrior agents drawing similar subjects learned:\n${lines.join("\n")}`;
+}
+
+/** System prompt for the DRAW pass. */
+export function buildDrawSystemPrompt(wisdom: Wisdom[]): string {
+  return `You are an expert artist working in MS Paint (Windows 3.1 style). You draw by emitting a sequence of paint commands as JSON.
+
+${PAINT_COMMAND_SPEC}
+${renderWisdom(wisdom)}
+
+## How to think (do this before drawing)
+1. Block in big shapes and background first, then mid-tones, then details last.
+2. Pick a small, deliberate colour set from the palette.
+3. Use filled shapes for masses; use lines/curves for contours; use spray for texture/shading.
+4. Keep everything inside the 640x480 canvas.
+
+## Response format — return ONLY this JSON object, no prose around it:
+{
+  "thinking": "your artistic reasoning",
+  "plan": ["ordered steps you will take, e.g. 'sky gradient', 'mountain silhouette', 'sun'"],
+  "description": "one short sentence describing the result",
+  "commands": [ ...paint commands... ]
+}`;
+}
+
+/**
+ * System prompt for the REFLECT pass — elicits a Cognitive Demands Table
+ * (Militello & Hutton) + a Knowledge Audit from the agent about the drawing
+ * it just produced. Output feeds the lessons store.
+ */
+export const REFLECTION_SYSTEM_PROMPT = `You are a drawing coach running a cognitive task analysis on an MS Paint AI agent that just finished a drawing. Elicit transferable expertise.
+
+Return ONLY this JSON object:
+{
+  "difficultElement": "the single most cognitively demanding part of drawing this subject",
+  "whyDifficult": "why that part is hard in MS Paint specifically",
+  "commonErrors": "the typical mistake a novice agent makes here",
+  "cuesAndStrategies": "the concrete technique/cue an expert uses to get it right (actionable, specific to the command set)",
+  "whatWorked": ["1-3 things that went well in this attempt"],
+  "whatDidnt": ["1-3 things that fell short"],
+  "wishIKnew": "one thing that would have helped before starting",
+  "doDifferently": "the single highest-leverage change for next time",
+  "toolsNeeded": ["paint commands/tools most central to this subject"]
+}
+Be specific and reusable — another agent drawing the same category should be able to act on cuesAndStrategies and doDifferently.`;
+
+/** Build the reflection user message from the drawing result. */
+export function buildReflectionUserContent(
+  prompt: string,
+  category: string | null,
+  description: string | null,
+  commandCount: number
+): string {
+  return `Prompt: "${prompt}"
+Category: ${category || "general"}
+Agent's description of result: ${description || "(none)"}
+Commands emitted: ${commandCount}
+
+Produce the cognitive task analysis JSON now.`;
+}
+
+/** Extract the first balanced JSON object from a model's text output. */
+export function extractJson<T = Record<string, unknown>>(text: string): T | null {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[0]) as T;
+  } catch {
+    return null;
+  }
+}

--- a/website-next/functions/_lib/cta.ts
+++ b/website-next/functions/_lib/cta.ts
@@ -64,10 +64,23 @@ ${PAINT_COMMAND_SPEC}
 ${renderWisdom(wisdom)}
 
 ## How to think (do this before drawing)
-1. Block in big shapes and background first, then mid-tones, then details last.
-2. Pick a small, deliberate colour set from the palette.
-3. Use filled shapes for masses; use lines/curves for contours; use spray for texture/shading.
-4. Keep everything inside the 640x480 canvas.
+1. DECOMPOSE the subject into its real parts and draw each one. "A cowboy on a
+   horse" = horse body + 4 legs + neck + head + tail, THEN rider torso + arms +
+   hat, THEN ground and sky. Draw the thing's actual anatomy/structure, not a
+   single box standing in for it.
+2. Block in big shapes and background first, then mid-tones, then details last.
+3. Pick a small, deliberate colour set from the palette.
+4. Use filled shapes for masses; lines/curves for contours/limbs; spray for texture.
+5. Keep everything inside the 640x480 canvas and cover the whole frame — no large
+   empty grey/blank regions unless they are deliberately sky, ground, or water.
+
+## Hard rules (breaking these ruins the drawing)
+- NEVER write the name of the subject as text to substitute for drawing it.
+  Writing "cowboy" instead of drawing a cowboy is a failure. \`placeText\` is ONLY
+  for text that genuinely belongs IN the scene (a sign, a banner) — never a label.
+- Be generous with commands. A recognizable subject usually needs 25-60 commands;
+  a handful of rectangles is not a drawing. Build each part from multiple shapes.
+- Make it READABLE as the subject: someone should recognize it without the prompt.
 
 ## Finishing the job (important)
 Do NOT stop early with a sparse, unfinished drawing. If you would run out of
@@ -197,13 +210,47 @@ Commands emitted: ${commandCount}${traceBlock}
 Produce the cognitive task analysis JSON now${trace ? ", grounded in the trace above" : ""}.`;
 }
 
-/** Extract the first balanced JSON object from a model's text output. */
+/**
+ * Strip the JSON-illegal noise LLMs commonly emit — `//` line comments and
+ * `/* *​/` block comments — but ONLY outside string literals, so values like
+ * "http://..." or "#000000" survive untouched.
+ */
+function stripJsonNoise(s: string): string {
+  let out = "";
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      out += c;
+      if (esc) esc = false;
+      else if (c === "\\") esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') { inStr = true; out += c; continue; }
+    if (c === "/" && s[i + 1] === "/") { while (i < s.length && s[i] !== "\n") i++; out += "\n"; continue; }
+    if (c === "/" && s[i + 1] === "*") { i += 2; while (i < s.length && !(s[i] === "*" && s[i + 1] === "/")) i++; i++; continue; }
+    out += c;
+  }
+  return out;
+}
+
+/**
+ * Extract the first balanced JSON object from a model's text output, tolerating
+ * the usual LLM mistakes: ```code fences```, `//` and block comments, and
+ * trailing commas. Tries the raw slice first (fast path), then a repaired one.
+ */
 export function extractJson<T = Record<string, unknown>>(text: string): T | null {
   const match = text.match(/\{[\s\S]*\}/);
   if (!match) return null;
-  try {
-    return JSON.parse(match[0]) as T;
-  } catch {
-    return null;
+  const repaired = stripJsonNoise(match[0]).replace(/,(\s*[}\]])/g, "$1");
+  for (const candidate of [match[0], repaired]) {
+    try {
+      return JSON.parse(candidate) as T;
+    } catch {
+      /* try the next candidate */
+    }
   }
+  return null;
 }

--- a/website-next/functions/_lib/db.ts
+++ b/website-next/functions/_lib/db.ts
@@ -18,6 +18,28 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
+/** Read a config value (returns null if absent or no DB). */
+export async function getConfig(env: Env, key: string): Promise<string | null> {
+  if (!env.MSPAINT_DB) return null;
+  const row = await env.MSPAINT_DB.prepare("SELECT value FROM config WHERE key = ?")
+    .bind(key)
+    .first<{ value: string }>();
+  return row ? row.value : null;
+}
+
+/** Upsert a config value. */
+export async function setConfig(env: Env, key: string, value: string): Promise<void> {
+  if (!env.MSPAINT_DB) return;
+  await env.MSPAINT_DB.prepare(
+    `INSERT INTO config (key, value, updated_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+  )
+    .bind(key, value, nowIso())
+    .run();
+}
+
+export const CONFIG_MODEL_KEY = "cf_text_model";
+
 /**
  * Find-or-create the user row, keyed primarily on the cookie UUID but
  * reconciled against the IP/UA hash so a fresh cookie can't reset the count

--- a/website-next/functions/_lib/db.ts
+++ b/website-next/functions/_lib/db.ts
@@ -40,6 +40,103 @@ export async function setConfig(env: Env, key: string, value: string): Promise<v
 
 export const CONFIG_MODEL_KEY = "cf_text_model";
 
+// --- Public feature flags (what non-admin visitors get) -------------------
+export interface FeatureFlags {
+  references: boolean; // look at reference photos before drawing
+  critique: boolean; // vision critique of the final render
+  iterative: boolean; // allow agent-requested extra drawing turns
+  maxTurns: number; // cap on total draw turns for the public
+}
+
+const FLAG_KEY = "public_features";
+const DEFAULT_FLAGS: FeatureFlags = {
+  references: false,
+  critique: false,
+  iterative: false,
+  maxTurns: 1,
+};
+
+export async function getFlags(env: Env): Promise<FeatureFlags> {
+  const raw = await getConfig(env, FLAG_KEY);
+  if (!raw) return { ...DEFAULT_FLAGS };
+  try {
+    return { ...DEFAULT_FLAGS, ...(JSON.parse(raw) as Partial<FeatureFlags>) };
+  } catch {
+    return { ...DEFAULT_FLAGS };
+  }
+}
+
+export async function setFlags(env: Env, flags: FeatureFlags): Promise<void> {
+  await setConfig(env, FLAG_KEY, JSON.stringify(flags));
+}
+
+// --- Replay-grade event log -----------------------------------------------
+export interface EventRecord {
+  generationId: string;
+  batchId?: string | null;
+  seq: number;
+  phase: string; // assess | search | look | plan | draw | turn | critique
+  type: string;
+  data: unknown;
+}
+
+export async function recordEvent(env: Env, e: EventRecord): Promise<void> {
+  if (!env.MSPAINT_DB) return;
+  await env.MSPAINT_DB.prepare(
+    `INSERT INTO gen_events (id, generation_id, batch_id, seq, ts, phase, type, data)
+     VALUES (?,?,?,?,?,?,?,?)`
+  )
+    .bind(
+      crypto.randomUUID(),
+      e.generationId,
+      e.batchId ?? null,
+      e.seq,
+      new Date().toISOString(),
+      e.phase,
+      e.type,
+      e.data === undefined ? null : JSON.stringify(e.data)
+    )
+    .run();
+}
+
+export async function getEvents(env: Env, generationId: string): Promise<Record<string, unknown>[]> {
+  if (!env.MSPAINT_DB) return [];
+  const { results } = await env.MSPAINT_DB.prepare(
+    `SELECT * FROM gen_events WHERE generation_id = ? ORDER BY seq ASC`
+  )
+    .bind(generationId)
+    .all<Record<string, unknown>>();
+  return results || [];
+}
+
+export async function getGeneration(env: Env, id: string): Promise<Record<string, unknown> | null> {
+  if (!env.MSPAINT_DB) return null;
+  return (
+    (await env.MSPAINT_DB.prepare("SELECT * FROM generations WHERE id = ?")
+      .bind(id)
+      .first<Record<string, unknown>>()) || null
+  );
+}
+
+export async function updateGenerationFinal(
+  env: Env,
+  id: string,
+  f: { passCount?: number; referenceKeys?: unknown; aestheticScore?: number | null; critique?: string | null }
+): Promise<void> {
+  if (!env.MSPAINT_DB) return;
+  await env.MSPAINT_DB.prepare(
+    `UPDATE generations SET pass_count = ?, reference_keys = ?, aesthetic_score = ?, critique = ? WHERE id = ?`
+  )
+    .bind(
+      f.passCount ?? null,
+      f.referenceKeys === undefined ? null : JSON.stringify(f.referenceKeys),
+      f.aestheticScore ?? null,
+      f.critique ?? null,
+      id
+    )
+    .run();
+}
+
 /**
  * Find-or-create the user row, keyed primarily on the cookie UUID but
  * reconciled against the IP/UA hash so a fresh cookie can't reset the count
@@ -277,6 +374,7 @@ export interface LessonRecord {
   doDifferently?: string | null;
   toolsNeeded?: unknown;
   aestheticScore?: number | null;
+  sawImage?: boolean;
 }
 
 export async function recordLesson(env: Env, l: LessonRecord): Promise<void> {
@@ -286,8 +384,8 @@ export async function recordLesson(env: Env, l: LessonRecord): Promise<void> {
         id, generation_id, created_at, category, subcategories,
         difficult_element, why_difficult, common_errors, cues_and_strategies,
         what_worked, what_didnt, wish_i_knew, do_differently, tools_needed,
-        aesthetic_score, helpfulness
-      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,0)`
+        aesthetic_score, helpfulness, saw_image
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,0,?)`
     )
     .bind(
       l.id,
@@ -304,7 +402,8 @@ export async function recordLesson(env: Env, l: LessonRecord): Promise<void> {
       l.wishIKnew ?? null,
       l.doDifferently ?? null,
       j(l.toolsNeeded),
-      l.aestheticScore ?? null
+      l.aestheticScore ?? null,
+      l.sawImage ? 1 : 0
     )
     .run();
 }

--- a/website-next/functions/_lib/db.ts
+++ b/website-next/functions/_lib/db.ts
@@ -1,0 +1,266 @@
+/**
+ * D1 access layer: anonymous-user quota, generation logging, and the
+ * expertise-accrual store (lessons = Cognitive Demands Table + Knowledge Audit).
+ */
+
+import type { Env } from "./env";
+import { freeLimit } from "./env";
+import type { Identity } from "./identity";
+
+export interface QuotaState {
+  used: number;
+  limit: number;
+  remaining: number;
+  exceeded: boolean;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Find-or-create the user row, keyed primarily on the cookie UUID but
+ * reconciled against the IP/UA hash so a fresh cookie can't reset the count
+ * if we've recently seen the same device. Returns the merged quota state.
+ */
+export async function getOrCreateUser(
+  env: Env,
+  id: Identity
+): Promise<{ userId: string; quota: QuotaState }> {
+  const db = env.MSPAINT_DB!;
+  const limit = freeLimit(env);
+  const ts = nowIso();
+
+  // Try the cookie first.
+  let row = await db
+    .prepare("SELECT * FROM users WHERE id = ?")
+    .bind(id.cookieUuid)
+    .first<Record<string, unknown>>();
+
+  // Fall back to the strongest IP/UA match (most uses) if no cookie row.
+  if (!row) {
+    row = await db
+      .prepare(
+        "SELECT * FROM users WHERE ip_ua_hash = ? ORDER BY free_uses_used DESC LIMIT 1"
+      )
+      .bind(id.ipUaHash)
+      .first<Record<string, unknown>>();
+  }
+
+  if (!row) {
+    await db
+      .prepare(
+        `INSERT INTO users (id, cookie_uuid, ip_ua_hash, free_uses_used, total_uses, first_seen, last_seen, country, user_agent)
+         VALUES (?, ?, ?, 0, 0, ?, ?, ?, ?)`
+      )
+      .bind(id.cookieUuid, id.cookieUuid, id.ipUaHash, ts, ts, id.country, id.userAgent)
+      .run();
+    return {
+      userId: id.cookieUuid,
+      quota: { used: 0, limit, remaining: limit, exceeded: false },
+    };
+  }
+
+  const userId = String(row.id);
+  const used = Number(row.free_uses_used) || 0;
+  await db
+    .prepare("UPDATE users SET last_seen = ?, ip_ua_hash = ?, country = ? WHERE id = ?")
+    .bind(ts, id.ipUaHash, id.country, userId)
+    .run();
+
+  const remaining = Math.max(0, limit - used);
+  return {
+    userId,
+    quota: { used, limit, remaining, exceeded: remaining <= 0 },
+  };
+}
+
+/** Read-only quota lookup for the usage endpoint. */
+export async function readQuota(env: Env, id: Identity): Promise<QuotaState> {
+  const db = env.MSPAINT_DB!;
+  const limit = freeLimit(env);
+  const row =
+    (await db
+      .prepare("SELECT free_uses_used FROM users WHERE id = ?")
+      .bind(id.cookieUuid)
+      .first<{ free_uses_used: number }>()) ||
+    (await db
+      .prepare(
+        "SELECT free_uses_used FROM users WHERE ip_ua_hash = ? ORDER BY free_uses_used DESC LIMIT 1"
+      )
+      .bind(id.ipUaHash)
+      .first<{ free_uses_used: number }>());
+
+  const used = row ? Number(row.free_uses_used) || 0 : 0;
+  const remaining = Math.max(0, limit - used);
+  return { used, limit, remaining, exceeded: remaining <= 0 };
+}
+
+/** Increment the free-use counter (only called for the free CF path). */
+export async function consumeFreeUse(env: Env, userId: string): Promise<void> {
+  await env
+    .MSPAINT_DB!.prepare(
+      "UPDATE users SET free_uses_used = free_uses_used + 1, total_uses = total_uses + 1 WHERE id = ?"
+    )
+    .bind(userId)
+    .run();
+}
+
+/** Bump only total_uses (for unlimited bring-your-own-key generations). */
+export async function bumpTotal(env: Env, userId: string): Promise<void> {
+  await env
+    .MSPAINT_DB!.prepare("UPDATE users SET total_uses = total_uses + 1 WHERE id = ?")
+    .bind(userId)
+    .run();
+}
+
+export interface GenerationRecord {
+  id: string;
+  userId: string;
+  identity: Identity;
+  provider: string;
+  model: string;
+  prompt: string;
+  category?: string | null;
+  subcategories?: unknown;
+  recommendedTools?: unknown;
+  referenceQuery?: string | null;
+  thinking?: string | null;
+  plan?: unknown;
+  description?: string | null;
+  commands?: unknown;
+  commandCount?: number;
+  canvasBeforeKey?: string | null;
+  canvasAfterKey?: string | null;
+  usageTokens?: unknown;
+  latencyMs?: number;
+  status: string;
+  error?: string | null;
+}
+
+const j = (v: unknown): string | null =>
+  v === undefined || v === null ? null : JSON.stringify(v);
+
+export async function recordGeneration(env: Env, r: GenerationRecord): Promise<void> {
+  await env
+    .MSPAINT_DB!.prepare(
+      `INSERT INTO generations (
+        id, created_at, user_id, cookie_uuid, ip_ua_hash, country, user_agent,
+        provider, model, prompt, category, subcategories, recommended_tools,
+        reference_query, thinking, plan, description, commands, command_count,
+        canvas_before_key, canvas_after_key, usage_tokens, latency_ms, status, error
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+    )
+    .bind(
+      r.id,
+      nowIso(),
+      r.userId,
+      r.identity.cookieUuid,
+      r.identity.ipUaHash,
+      r.identity.country,
+      r.identity.userAgent,
+      r.provider,
+      r.model,
+      r.prompt,
+      r.category ?? null,
+      j(r.subcategories),
+      j(r.recommendedTools),
+      r.referenceQuery ?? null,
+      r.thinking ?? null,
+      j(r.plan),
+      r.description ?? null,
+      j(r.commands),
+      r.commandCount ?? null,
+      r.canvasBeforeKey ?? null,
+      r.canvasAfterKey ?? null,
+      j(r.usageTokens),
+      r.latencyMs ?? null,
+      r.status,
+      r.error ?? null
+    )
+    .run();
+}
+
+export interface LessonRecord {
+  id: string;
+  generationId: string;
+  category?: string | null;
+  subcategories?: unknown;
+  difficultElement?: string | null;
+  whyDifficult?: string | null;
+  commonErrors?: string | null;
+  cuesAndStrategies?: string | null;
+  whatWorked?: unknown;
+  whatDidnt?: unknown;
+  wishIKnew?: string | null;
+  doDifferently?: string | null;
+  toolsNeeded?: unknown;
+  aestheticScore?: number | null;
+}
+
+export async function recordLesson(env: Env, l: LessonRecord): Promise<void> {
+  await env
+    .MSPAINT_DB!.prepare(
+      `INSERT INTO lessons (
+        id, generation_id, created_at, category, subcategories,
+        difficult_element, why_difficult, common_errors, cues_and_strategies,
+        what_worked, what_didnt, wish_i_knew, do_differently, tools_needed,
+        aesthetic_score, helpfulness
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,0)`
+    )
+    .bind(
+      l.id,
+      l.generationId,
+      nowIso(),
+      l.category ?? null,
+      j(l.subcategories),
+      l.difficultElement ?? null,
+      l.whyDifficult ?? null,
+      l.commonErrors ?? null,
+      l.cuesAndStrategies ?? null,
+      j(l.whatWorked),
+      j(l.whatDidnt),
+      l.wishIKnew ?? null,
+      l.doDifferently ?? null,
+      j(l.toolsNeeded),
+      l.aestheticScore ?? null
+    )
+    .run();
+}
+
+export interface Wisdom {
+  difficultElement: string | null;
+  whyDifficult: string | null;
+  cuesAndStrategies: string | null;
+  doDifferently: string | null;
+}
+
+/**
+ * Retrieve the most useful accrued lessons for a category — this is the
+ * Shadowbox feedback loop. Newest-first, lightly favouring higher helpfulness.
+ */
+export async function retrieveWisdom(
+  env: Env,
+  category: string | null,
+  limit = 4
+): Promise<Wisdom[]> {
+  if (!env.MSPAINT_DB) return [];
+  const cat = category || "general";
+  const { results } = await env.MSPAINT_DB.prepare(
+    `SELECT difficult_element, why_difficult, cues_and_strategies, do_differently
+       FROM lessons
+      WHERE category = ?
+        AND (cues_and_strategies IS NOT NULL OR do_differently IS NOT NULL)
+      ORDER BY helpfulness DESC, created_at DESC
+      LIMIT ?`
+  )
+    .bind(cat, limit)
+    .all<Record<string, string | null>>();
+
+  return (results || []).map((r) => ({
+    difficultElement: r.difficult_element,
+    whyDifficult: r.why_difficult,
+    cuesAndStrategies: r.cues_and_strategies,
+    doDifferently: r.do_differently,
+  }));
+}

--- a/website-next/functions/_lib/db.ts
+++ b/website-next/functions/_lib/db.ts
@@ -158,6 +158,7 @@ export interface GenerationRecord {
   latencyMs?: number;
   status: string;
   error?: string | null;
+  batchId?: string | null;
 }
 
 const j = (v: unknown): string | null =>
@@ -170,8 +171,8 @@ export async function recordGeneration(env: Env, r: GenerationRecord): Promise<v
         id, created_at, user_id, cookie_uuid, ip_ua_hash, country, user_agent,
         provider, model, prompt, category, subcategories, recommended_tools,
         reference_query, thinking, plan, description, commands, command_count,
-        canvas_before_key, canvas_after_key, usage_tokens, latency_ms, status, error
-      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+        canvas_before_key, canvas_after_key, usage_tokens, latency_ms, status, error, batch_id
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
     )
     .bind(
       r.id,
@@ -198,9 +199,67 @@ export async function recordGeneration(env: Env, r: GenerationRecord): Promise<v
       j(r.usageTokens),
       r.latencyMs ?? null,
       r.status,
-      r.error ?? null
+      r.error ?? null,
+      r.batchId ?? null
     )
     .run();
+}
+
+// --- Batch runs (admin soak tests) ---------------------------------------
+export async function createBatch(
+  env: Env,
+  b: { id: string; model: string; prompt: string; target: number }
+): Promise<void> {
+  if (!env.MSPAINT_DB) return;
+  await env.MSPAINT_DB.prepare(
+    `INSERT INTO batches (id, created_at, model, prompt, target, completed, ok_count, fail_count, status)
+     VALUES (?,?,?,?,?,0,0,0,'running')`
+  )
+    .bind(b.id, nowIso(), b.model, b.prompt, b.target)
+    .run();
+}
+
+export async function incrementBatch(env: Env, id: string, ok: boolean): Promise<void> {
+  if (!env.MSPAINT_DB) return;
+  await env.MSPAINT_DB.prepare(
+    `UPDATE batches SET completed = completed + 1,
+       ok_count = ok_count + ?, fail_count = fail_count + ?,
+       status = CASE WHEN completed + 1 >= target THEN 'done' ELSE status END
+     WHERE id = ?`
+  )
+    .bind(ok ? 1 : 0, ok ? 0 : 1, id)
+    .run();
+}
+
+// --- Wisdom explorer ------------------------------------------------------
+export interface CategorySummary {
+  category: string;
+  lessons: number;
+}
+
+export async function listLessonCategories(env: Env): Promise<CategorySummary[]> {
+  if (!env.MSPAINT_DB) return [];
+  const { results } = await env.MSPAINT_DB.prepare(
+    `SELECT category, COUNT(*) AS lessons FROM lessons GROUP BY category ORDER BY lessons DESC`
+  ).all<{ category: string; lessons: number }>();
+  return (results || []).map((r) => ({ category: r.category || "general", lessons: r.lessons }));
+}
+
+export async function getLessons(
+  env: Env,
+  category: string | null,
+  limit = 100
+): Promise<Record<string, unknown>[]> {
+  if (!env.MSPAINT_DB) return [];
+  const stmt = category
+    ? env.MSPAINT_DB.prepare(
+        `SELECT * FROM lessons WHERE category = ? ORDER BY helpfulness DESC, created_at DESC LIMIT ?`
+      ).bind(category, limit)
+    : env.MSPAINT_DB.prepare(
+        `SELECT * FROM lessons ORDER BY created_at DESC LIMIT ?`
+      ).bind(limit);
+  const { results } = await stmt.all<Record<string, unknown>>();
+  return results || [];
 }
 
 export interface LessonRecord {

--- a/website-next/functions/_lib/env.ts
+++ b/website-next/functions/_lib/env.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared binding/types for MS Paint Pages Functions.
+ */
+
+export interface Env {
+  // Bindings (see wrangler.toml)
+  AI?: { run: (model: string, input: Record<string, unknown>) => Promise<unknown> };
+  MSPAINT_DB?: D1Database;
+  MSPAINT_BUCKET?: R2Bucket;
+
+  // Vars
+  FREE_USES_LIMIT?: string;
+  CF_TEXT_MODEL?: string;
+
+  // Secrets
+  ADMIN_TOKEN?: string;
+  IDENTITY_SALT?: string;
+  ANTHROPIC_API_KEY?: string;
+  PEXELS_API_KEY?: string;
+}
+
+export const DEFAULT_FREE_LIMIT = 5;
+export const DEFAULT_CF_MODEL = "@cf/meta/llama-3.1-8b-instruct";
+
+export function freeLimit(env: Env): number {
+  const n = parseInt(env.FREE_USES_LIMIT || "", 10);
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_FREE_LIMIT;
+}

--- a/website-next/functions/_lib/identity.ts
+++ b/website-next/functions/_lib/identity.ts
@@ -1,0 +1,85 @@
+/**
+ * Anonymous user identification.
+ *
+ * MAC addresses are NOT available to web servers — browsers never expose them.
+ * We use a hybrid the user can't trivially evade but that stays privacy-light:
+ *   1. PRIMARY: a first-party anonymous UUID stored in an httpOnly cookie.
+ *   2. BACKUP:  sha256(ip + user-agent + salt) — survives cookie clearing,
+ *      catches the obvious "incognito to get more free uses" case.
+ *
+ * The IP itself is never stored in plaintext; only its salted hash is kept.
+ */
+
+import type { Env } from "./env";
+
+const COOKIE_NAME = "scs_mspaint_id";
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+export interface Identity {
+  cookieUuid: string;
+  ipUaHash: string;
+  isNewCookie: boolean;
+  country: string | null;
+  userAgent: string;
+}
+
+function parseCookies(header: string | null): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(";")) {
+    const idx = part.indexOf("=");
+    if (idx === -1) continue;
+    const k = part.slice(0, idx).trim();
+    const v = part.slice(idx + 1).trim();
+    if (k) out[k] = decodeURIComponent(v);
+  }
+  return out;
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function uuid(): string {
+  return crypto.randomUUID();
+}
+
+export async function identify(request: Request, env: Env): Promise<Identity> {
+  const cookies = parseCookies(request.headers.get("Cookie"));
+  let cookieUuid = cookies[COOKIE_NAME];
+  let isNewCookie = false;
+  if (!cookieUuid || cookieUuid.length < 8) {
+    cookieUuid = uuid();
+    isNewCookie = true;
+  }
+
+  // Cloudflare-provided client signals.
+  const ip =
+    request.headers.get("CF-Connecting-IP") ||
+    request.headers.get("X-Forwarded-For") ||
+    "0.0.0.0";
+  const ua = request.headers.get("User-Agent") || "unknown";
+  // @ts-expect-error cf is added by the Cloudflare runtime
+  const country: string | null = request.cf?.country ?? null;
+
+  const salt = env.IDENTITY_SALT || "scs-mspaint-default-salt";
+  const ipUaHash = await sha256Hex(`${ip}::${ua}::${salt}`);
+
+  return { cookieUuid, ipUaHash, isNewCookie, country, userAgent: ua };
+}
+
+/** Set-Cookie header value that persists the anonymous id. */
+export function identityCookie(cookieUuid: string): string {
+  return [
+    `${COOKIE_NAME}=${encodeURIComponent(cookieUuid)}`,
+    "Path=/",
+    `Max-Age=${COOKIE_MAX_AGE}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ].join("; ");
+}

--- a/website-next/functions/_lib/models.ts
+++ b/website-next/functions/_lib/models.ts
@@ -192,7 +192,7 @@ export function hasReasoning(id: string): boolean {
 /** Output-token budget for a draw call. Reasoning models burn much of the
  *  budget on their chain-of-thought before the JSON, so they get more room —
  *  otherwise the command array is truncated mid-stream and fails to parse. */
-export const DRAW_MAX_TOKENS = 4096;
+export const DRAW_MAX_TOKENS = 8192;
 export const DRAW_MAX_TOKENS_REASONING = 12000;
 export function drawBudget(id: string): number {
   return hasReasoning(id) ? DRAW_MAX_TOKENS_REASONING : DRAW_MAX_TOKENS;

--- a/website-next/functions/_lib/models.ts
+++ b/website-next/functions/_lib/models.ts
@@ -25,6 +25,12 @@ export interface ModelInfo {
   api?: "messages" | "responses";
   /** Can accept image input (reference photos / its own canvas). */
   vision?: boolean;
+  /**
+   * Emits a chain-of-thought before its answer (qwen3, QwQ, gpt-oss, Kimi).
+   * Reasoning shares the output token budget, so these need a larger draw
+   * budget or the command JSON gets truncated mid-array. See DRAW_MAX_TOKENS.
+   */
+  reasoning?: boolean;
   /** Highlight in the picker: the headline best / worst pick. */
   extreme?: "best" | "worst";
 }
@@ -47,6 +53,7 @@ export const MODEL_CATALOG: ModelInfo[] = [
   // ---- The best -----------------------------------------------------------
   m({
     id: "@cf/moonshotai/kimi-k2.7-code",
+    reasoning: true,
     label: "Kimi K2.7 Code",
     vendor: "Moonshot AI",
     inPrice: 0.95,
@@ -58,6 +65,7 @@ export const MODEL_CATALOG: ModelInfo[] = [
   }),
   m({
     id: "@cf/openai/gpt-oss-120b",
+    reasoning: true,
     label: "GPT-OSS 120B",
     vendor: "OpenAI",
     inPrice: 0.35,
@@ -78,6 +86,7 @@ export const MODEL_CATALOG: ModelInfo[] = [
   }),
   m({
     id: "@cf/qwen/qwq-32b",
+    reasoning: true,
     label: "QwQ 32B (reasoning)",
     vendor: "Qwen",
     inPrice: 0.66,
@@ -88,6 +97,7 @@ export const MODEL_CATALOG: ModelInfo[] = [
   // ---- Value sweet spots --------------------------------------------------
   m({
     id: "@cf/openai/gpt-oss-20b",
+    reasoning: true,
     label: "GPT-OSS 20B",
     vendor: "OpenAI",
     inPrice: 0.2,
@@ -98,6 +108,7 @@ export const MODEL_CATALOG: ModelInfo[] = [
   }),
   m({
     id: "@cf/qwen/qwen3-30b-a3b-fp8",
+    reasoning: true,
     label: "Qwen3 30B-A3B (fp8)",
     vendor: "Qwen",
     inPrice: 0.051,
@@ -172,6 +183,19 @@ export function modelApi(id: string): "messages" | "responses" {
 
 export function hasVision(id: string): boolean {
   return !!modelInfo(id)?.vision;
+}
+
+export function hasReasoning(id: string): boolean {
+  return !!modelInfo(id)?.reasoning;
+}
+
+/** Output-token budget for a draw call. Reasoning models burn much of the
+ *  budget on their chain-of-thought before the JSON, so they get more room —
+ *  otherwise the command array is truncated mid-stream and fails to parse. */
+export const DRAW_MAX_TOKENS = 4096;
+export const DRAW_MAX_TOKENS_REASONING = 12000;
+export function drawBudget(id: string): number {
+  return hasReasoning(id) ? DRAW_MAX_TOKENS_REASONING : DRAW_MAX_TOKENS;
 }
 
 /** Cheapest capable vision model — used as the "critic" that sees renders. */

--- a/website-next/functions/_lib/models.ts
+++ b/website-next/functions/_lib/models.ts
@@ -9,6 +9,8 @@
  * Only models in this catalog can be selected from the admin tool.
  */
 
+export type Tier = "worst" | "cheap" | "value" | "mid" | "premium" | "best";
+
 export interface ModelInfo {
   id: string;
   label: string;
@@ -16,8 +18,13 @@ export interface ModelInfo {
   inPrice: number; // $ / M input tokens
   outPrice: number; // $ / M output tokens
   perDrawing: string; // estimated $ per drawing
+  tier: Tier;
   note: string;
   recommended?: boolean;
+  /** Family schema for invocation: "messages" (chat) or "responses" (gpt-oss). */
+  api?: "messages" | "responses";
+  /** Highlight in the picker: the headline best / worst pick. */
+  extreme?: "best" | "worst";
 }
 
 // Estimated tokens per drawing for the perDrawing figure.
@@ -28,71 +35,133 @@ export function estPerDrawing(inPrice: number, outPrice: number): string {
   return `$${usd.toFixed(4)}`;
 }
 
+function m(
+  o: Omit<ModelInfo, "perDrawing">
+): ModelInfo {
+  return { ...o, perDrawing: estPerDrawing(o.inPrice, o.outPrice) };
+}
+
 export const MODEL_CATALOG: ModelInfo[] = [
-  {
-    id: "@cf/meta/llama-3.1-8b-instruct-fp8-fast",
-    label: "Llama 3.1 8B (fp8, fast)",
+  // ---- The best -----------------------------------------------------------
+  m({
+    id: "@cf/moonshotai/kimi-k2.7-code",
+    label: "Kimi K2.7 Code",
+    vendor: "Moonshot AI",
+    inPrice: 0.95,
+    outPrice: 4.0,
+    tier: "best",
+    extreme: "best",
+    note: "THE BEST: frontier 1T-param MoE (32B active), 262K context, reasoning + vision + native structured JSON outputs. Most capable here; priciest output.",
+  }),
+  m({
+    id: "@cf/openai/gpt-oss-120b",
+    label: "GPT-OSS 120B",
+    vendor: "OpenAI",
+    inPrice: 0.35,
+    outPrice: 0.75,
+    tier: "best",
+    api: "responses",
+    note: "Best value flagship: OpenAI open-weight, top reasoning + agentic, 128K context, function calling. Strict JSON at a fraction of Kimi's output cost.",
+  }),
+  m({
+    id: "@cf/meta/llama-4-scout-17b-16e-instruct",
+    label: "Llama 4 Scout 17B-16E",
     vendor: "Meta",
-    inPrice: 0.045,
-    outPrice: 0.384,
-    perDrawing: estPerDrawing(0.045, 0.384),
-    note: "Cheapest fast option. Good for simple sketches; weakest at strict JSON.",
-  },
-  {
-    id: "@cf/meta/llama-3.2-3b-instruct",
-    label: "Llama 3.2 3B",
-    vendor: "Meta",
-    inPrice: 0.051,
-    outPrice: 0.335,
-    perDrawing: estPerDrawing(0.051, 0.335),
-    note: "Tiny + cheap. Fine for basic shapes, can drift on complex prompts.",
-  },
-  {
+    inPrice: 0.27,
+    outPrice: 0.85,
+    tier: "premium",
+    note: "Meta flagship, multimodal MoE (16 experts), 131K context. Excellent value at the top end.",
+  }),
+  m({
+    id: "@cf/qwen/qwq-32b",
+    label: "QwQ 32B (reasoning)",
+    vendor: "Qwen",
+    inPrice: 0.66,
+    outPrice: 1.0,
+    tier: "premium",
+    note: "Dedicated reasoning model (o1-mini class). Plans carefully; slower + priciest input.",
+  }),
+  // ---- Value sweet spots --------------------------------------------------
+  m({
+    id: "@cf/openai/gpt-oss-20b",
+    label: "GPT-OSS 20B",
+    vendor: "OpenAI",
+    inPrice: 0.2,
+    outPrice: 0.3,
+    tier: "mid",
+    api: "responses",
+    note: "Reasoning + function calling at a fraction of 120B. Great quality-per-dollar.",
+  }),
+  m({
     id: "@cf/qwen/qwen3-30b-a3b-fp8",
     label: "Qwen3 30B-A3B (fp8)",
     vendor: "Qwen",
     inPrice: 0.051,
     outPrice: 0.34,
-    perDrawing: estPerDrawing(0.051, 0.34),
-    note: "Best value: MoE with reasoning + function-calling, near-3B price. Strong, reliable JSON.",
+    tier: "value",
     recommended: true,
-  },
-  {
+    note: "Best value: MoE w/ reasoning + function-calling at near-3B price. Reliable JSON. Default.",
+  }),
+  m({
     id: "@cf/meta/llama-3.1-8b-instruct-fp8",
     label: "Llama 3.1 8B (fp8)",
     vendor: "Meta",
     inPrice: 0.152,
     outPrice: 0.287,
-    perDrawing: estPerDrawing(0.152, 0.287),
-    note: "Balanced 8B, not deprecated. Solid general default.",
-  },
-  {
-    id: "@cf/mistralai/mistral-small-3.1-24b-instruct",
-    label: "Mistral Small 3.1 24B",
-    vendor: "Mistral",
-    inPrice: 0.351,
-    outPrice: 0.555,
-    perDrawing: estPerDrawing(0.351, 0.555),
-    note: "Mid-tier quality, instruction-following. Pricier per output.",
-  },
-  {
-    id: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-    label: "Llama 3.3 70B (fp8, fast)",
+    tier: "cheap",
+    note: "Balanced small model, not deprecated. Solid general default.",
+  }),
+  m({
+    id: "@cf/meta/llama-3.1-8b-instruct-fp8-fast",
+    label: "Llama 3.1 8B (fp8, fast)",
     vendor: "Meta",
-    inPrice: 0.293,
-    outPrice: 2.253,
-    perDrawing: estPerDrawing(0.293, 2.253),
-    note: "Most capable / best drawings. ~6x the cost of the cheap options.",
-  },
+    inPrice: 0.045,
+    outPrice: 0.384,
+    tier: "cheap",
+    note: "Fastest cheap option. Fine for simple sketches; can fumble strict JSON.",
+  }),
+  // ---- The worst ----------------------------------------------------------
+  m({
+    id: "@cf/meta/llama-3.2-3b-instruct",
+    label: "Llama 3.2 3B",
+    vendor: "Meta",
+    inPrice: 0.051,
+    outPrice: 0.335,
+    tier: "cheap",
+    note: "Tiny. Basic shapes only; drifts on complex prompts.",
+  }),
+  m({
+    id: "@cf/meta/llama-3.2-1b-instruct",
+    label: "Llama 3.2 1B",
+    vendor: "Meta",
+    inPrice: 0.027,
+    outPrice: 0.201,
+    tier: "worst",
+    extreme: "worst",
+    note: "THE WORST (quality): cheapest model on the platform. Frequently malformed JSON & crude output — great for a baseline.",
+  }),
+  m({
+    id: "@cf/meta/llama-2-7b-chat-fp16",
+    label: "Llama 2 7B (fp16)",
+    vendor: "Meta",
+    inPrice: 0.556,
+    outPrice: 6.667,
+    tier: "worst",
+    note: "WORST VALUE: ancient (deprecated) AND the most expensive output on the platform ($6.67/M). A cautionary trap.",
+  }),
 ];
 
 export const RECOMMENDED_MODEL =
-  MODEL_CATALOG.find((m) => m.recommended)?.id || MODEL_CATALOG[0].id;
+  MODEL_CATALOG.find((mi) => mi.recommended)?.id || MODEL_CATALOG[0].id;
 
 export function isAllowedModel(id: string): boolean {
-  return MODEL_CATALOG.some((m) => m.id === id);
+  return MODEL_CATALOG.some((mi) => mi.id === id);
 }
 
 export function modelInfo(id: string): ModelInfo | undefined {
-  return MODEL_CATALOG.find((m) => m.id === id);
+  return MODEL_CATALOG.find((mi) => mi.id === id);
+}
+
+export function modelApi(id: string): "messages" | "responses" {
+  return modelInfo(id)?.api || "messages";
 }

--- a/website-next/functions/_lib/models.ts
+++ b/website-next/functions/_lib/models.ts
@@ -23,6 +23,8 @@ export interface ModelInfo {
   recommended?: boolean;
   /** Family schema for invocation: "messages" (chat) or "responses" (gpt-oss). */
   api?: "messages" | "responses";
+  /** Can accept image input (reference photos / its own canvas). */
+  vision?: boolean;
   /** Highlight in the picker: the headline best / worst pick. */
   extreme?: "best" | "worst";
 }
@@ -51,6 +53,7 @@ export const MODEL_CATALOG: ModelInfo[] = [
     outPrice: 4.0,
     tier: "best",
     extreme: "best",
+    vision: true,
     note: "THE BEST: frontier 1T-param MoE (32B active), 262K context, reasoning + vision + native structured JSON outputs. Most capable here; priciest output.",
   }),
   m({
@@ -70,6 +73,7 @@ export const MODEL_CATALOG: ModelInfo[] = [
     inPrice: 0.27,
     outPrice: 0.85,
     tier: "premium",
+    vision: true,
     note: "Meta flagship, multimodal MoE (16 experts), 131K context. Excellent value at the top end.",
   }),
   m({
@@ -165,3 +169,10 @@ export function modelInfo(id: string): ModelInfo | undefined {
 export function modelApi(id: string): "messages" | "responses" {
   return modelInfo(id)?.api || "messages";
 }
+
+export function hasVision(id: string): boolean {
+  return !!modelInfo(id)?.vision;
+}
+
+/** Cheapest capable vision model — used as the "critic" that sees renders. */
+export const VISION_CRITIC_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";

--- a/website-next/functions/_lib/models.ts
+++ b/website-next/functions/_lib/models.ts
@@ -1,0 +1,98 @@
+/**
+ * Curated Cloudflare Workers AI models for the free drawing tier.
+ *
+ * Prices are Cloudflare's published per-token unit pricing (USD per 1M tokens),
+ * verified against https://developers.cloudflare.com/workers-ai/platform/pricing/.
+ * `perDrawing` is an estimate assuming ~1.5K input + ~2.5K output tokens per
+ * drawing (system prompt + injected wisdom in, command JSON out).
+ *
+ * Only models in this catalog can be selected from the admin tool.
+ */
+
+export interface ModelInfo {
+  id: string;
+  label: string;
+  vendor: string;
+  inPrice: number; // $ / M input tokens
+  outPrice: number; // $ / M output tokens
+  perDrawing: string; // estimated $ per drawing
+  note: string;
+  recommended?: boolean;
+}
+
+// Estimated tokens per drawing for the perDrawing figure.
+const IN_TOK = 1500;
+const OUT_TOK = 2500;
+export function estPerDrawing(inPrice: number, outPrice: number): string {
+  const usd = (IN_TOK / 1e6) * inPrice + (OUT_TOK / 1e6) * outPrice;
+  return `$${usd.toFixed(4)}`;
+}
+
+export const MODEL_CATALOG: ModelInfo[] = [
+  {
+    id: "@cf/meta/llama-3.1-8b-instruct-fp8-fast",
+    label: "Llama 3.1 8B (fp8, fast)",
+    vendor: "Meta",
+    inPrice: 0.045,
+    outPrice: 0.384,
+    perDrawing: estPerDrawing(0.045, 0.384),
+    note: "Cheapest fast option. Good for simple sketches; weakest at strict JSON.",
+  },
+  {
+    id: "@cf/meta/llama-3.2-3b-instruct",
+    label: "Llama 3.2 3B",
+    vendor: "Meta",
+    inPrice: 0.051,
+    outPrice: 0.335,
+    perDrawing: estPerDrawing(0.051, 0.335),
+    note: "Tiny + cheap. Fine for basic shapes, can drift on complex prompts.",
+  },
+  {
+    id: "@cf/qwen/qwen3-30b-a3b-fp8",
+    label: "Qwen3 30B-A3B (fp8)",
+    vendor: "Qwen",
+    inPrice: 0.051,
+    outPrice: 0.34,
+    perDrawing: estPerDrawing(0.051, 0.34),
+    note: "Best value: MoE with reasoning + function-calling, near-3B price. Strong, reliable JSON.",
+    recommended: true,
+  },
+  {
+    id: "@cf/meta/llama-3.1-8b-instruct-fp8",
+    label: "Llama 3.1 8B (fp8)",
+    vendor: "Meta",
+    inPrice: 0.152,
+    outPrice: 0.287,
+    perDrawing: estPerDrawing(0.152, 0.287),
+    note: "Balanced 8B, not deprecated. Solid general default.",
+  },
+  {
+    id: "@cf/mistralai/mistral-small-3.1-24b-instruct",
+    label: "Mistral Small 3.1 24B",
+    vendor: "Mistral",
+    inPrice: 0.351,
+    outPrice: 0.555,
+    perDrawing: estPerDrawing(0.351, 0.555),
+    note: "Mid-tier quality, instruction-following. Pricier per output.",
+  },
+  {
+    id: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+    label: "Llama 3.3 70B (fp8, fast)",
+    vendor: "Meta",
+    inPrice: 0.293,
+    outPrice: 2.253,
+    perDrawing: estPerDrawing(0.293, 2.253),
+    note: "Most capable / best drawings. ~6x the cost of the cheap options.",
+  },
+];
+
+export const RECOMMENDED_MODEL =
+  MODEL_CATALOG.find((m) => m.recommended)?.id || MODEL_CATALOG[0].id;
+
+export function isAllowedModel(id: string): boolean {
+  return MODEL_CATALOG.some((m) => m.id === id);
+}
+
+export function modelInfo(id: string): ModelInfo | undefined {
+  return MODEL_CATALOG.find((m) => m.id === id);
+}

--- a/website-next/functions/_lib/r2.ts
+++ b/website-next/functions/_lib/r2.ts
@@ -5,14 +5,35 @@
 
 import type { Env } from "./env";
 
-/** Decode a data URL or bare base64 PNG into bytes. */
-function decodePng(dataUrl: string): Uint8Array | null {
+/** Decode a data URL (any image type) or bare base64 into bytes + mime. */
+function decode(dataUrl: string): { bytes: Uint8Array; mime: string } | null {
   try {
-    const b64 = dataUrl.replace(/^data:image\/png;base64,/, "");
+    const match = dataUrl.match(/^data:([^;]+);base64,(.*)$/s);
+    const mime = match ? match[1] : "image/png";
+    const b64 = match ? match[2] : dataUrl;
     const bin = atob(b64);
     const bytes = new Uint8Array(bin.length);
     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-    return bytes;
+    return { bytes, mime };
+  } catch {
+    return null;
+  }
+}
+
+const decodePng = (d: string): Uint8Array | null => decode(d)?.bytes ?? null;
+
+/** Store any image data URL (jpeg/png) in R2. Returns key or null. */
+export async function storeDataUrl(
+  env: Env,
+  key: string,
+  dataUrl: string | undefined | null
+): Promise<string | null> {
+  if (!env.MSPAINT_BUCKET || !dataUrl) return null;
+  const d = decode(dataUrl);
+  if (!d || d.bytes.length === 0) return null;
+  try {
+    await env.MSPAINT_BUCKET.put(key, d.bytes, { httpMetadata: { contentType: d.mime } });
+    return key;
   } catch {
     return null;
   }

--- a/website-next/functions/_lib/r2.ts
+++ b/website-next/functions/_lib/r2.ts
@@ -1,0 +1,41 @@
+/**
+ * R2 storage for drawing snapshots. Images live in R2 (built for blobs);
+ * only the keys are kept in D1.
+ */
+
+import type { Env } from "./env";
+
+/** Decode a data URL or bare base64 PNG into bytes. */
+function decodePng(dataUrl: string): Uint8Array | null {
+  try {
+    const b64 = dataUrl.replace(/^data:image\/png;base64,/, "");
+    const bin = atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store a PNG in R2. Returns the key, or null if there's nothing to store /
+ * no bucket bound. Never throws — logging must not break generation.
+ */
+export async function storePng(
+  env: Env,
+  key: string,
+  dataUrl: string | undefined | null
+): Promise<string | null> {
+  if (!env.MSPAINT_BUCKET || !dataUrl) return null;
+  const bytes = decodePng(dataUrl);
+  if (!bytes || bytes.length === 0) return null;
+  try {
+    await env.MSPAINT_BUCKET.put(key, bytes, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    return key;
+  } catch {
+    return null;
+  }
+}

--- a/website-next/functions/_lib/references.ts
+++ b/website-next/functions/_lib/references.ts
@@ -1,0 +1,82 @@
+/**
+ * Reference-image search for the drawing agents ("summon & look at references").
+ * Worker-compatible (no Node Buffer/process.env) — fetches from Pexels and
+ * returns data URLs ready to hand to a vision model, plus attribution.
+ */
+
+import type { Env } from "./env";
+
+export interface RefImage {
+  url: string; // original photo url (attribution / logging)
+  dataUrl: string; // base64 data URL for the vision model
+  query: string;
+  photographer?: string;
+}
+
+const STOP = new Set([
+  "a", "an", "the", "draw", "paint", "create", "make", "sketch", "of", "with",
+  "and", "in", "on", "simple", "detailed", "cute", "please", "me", "scene", "style",
+]);
+
+export function searchTerms(prompt: string): string {
+  const cleaned = prompt.toLowerCase().replace(/[^\w\s-]/g, "");
+  const words = cleaned.split(/\s+/).filter((w) => w.length > 2 && !STOP.has(w));
+  return Array.from(new Set(words)).slice(0, 4).join(" ");
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let bin = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(bin);
+}
+
+/**
+ * Fetch up to `count` reference images for a prompt. Returns [] if no key or
+ * on any failure (never throws — references are an enhancement, not required).
+ */
+export async function searchReferences(
+  env: Env,
+  prompt: string,
+  count = 1
+): Promise<{ images: RefImage[]; query: string }> {
+  const key = env.PEXELS_API_KEY;
+  const query = searchTerms(prompt);
+  if (!key || !query) return { images: [], query };
+
+  try {
+    const res = await fetch(
+      `https://api.pexels.com/v1/search?query=${encodeURIComponent(query)}&per_page=${count}&size=small&orientation=landscape`,
+      { headers: { Authorization: key }, signal: AbortSignal.timeout(6000) }
+    );
+    if (!res.ok) return { images: [], query };
+    const data = (await res.json()) as {
+      photos?: Array<{ src?: { small?: string; tiny?: string; medium?: string }; photographer?: string }>;
+    };
+    const photos = (data.photos || []).slice(0, count);
+
+    const images: RefImage[] = [];
+    for (const p of photos) {
+      const imgUrl = p.src?.small || p.src?.tiny;
+      if (!imgUrl) continue;
+      try {
+        const ir = await fetch(imgUrl, { signal: AbortSignal.timeout(6000) });
+        if (!ir.ok) continue;
+        const bytes = new Uint8Array(await ir.arrayBuffer());
+        images.push({
+          url: p.src?.medium || imgUrl,
+          dataUrl: `data:image/jpeg;base64,${toBase64(bytes)}`,
+          query,
+          photographer: p.photographer,
+        });
+      } catch {
+        /* skip this image */
+      }
+    }
+    return { images, query };
+  } catch {
+    return { images: [], query };
+  }
+}

--- a/website-next/functions/_lib/workers-ai.ts
+++ b/website-next/functions/_lib/workers-ai.ts
@@ -5,26 +5,44 @@
  */
 
 import type { Env } from "./env";
-import { DEFAULT_CF_MODEL } from "./env";
 import { extractJson } from "./cta";
+import { getConfig, CONFIG_MODEL_KEY } from "./db";
+import { RECOMMENDED_MODEL, isAllowedModel } from "./models";
 
 interface CfTextResult {
   response?: string;
 }
 
+/** Synchronous fallback model (env var or recommended default). */
 export function cfModel(env: Env): string {
-  return env.CF_TEXT_MODEL || DEFAULT_CF_MODEL;
+  const fromEnv = env.CF_TEXT_MODEL;
+  if (fromEnv && isAllowedModel(fromEnv)) return fromEnv;
+  return RECOMMENDED_MODEL;
 }
+
+/**
+ * The drawing model, honoring the admin's runtime selection (D1 config),
+ * then the env var, then the recommended default. Validated against the catalog.
+ */
+export async function resolveDrawModel(env: Env): Promise<string> {
+  const fromConfig = await getConfig(env, CONFIG_MODEL_KEY);
+  if (fromConfig && isAllowedModel(fromConfig)) return fromConfig;
+  return cfModel(env);
+}
+
+/** Cheap, fixed model for utility passes (classification, reflection). */
+export const UTILITY_MODEL = RECOMMENDED_MODEL;
 
 /** Run a text model with a system + user message. Returns raw text. */
 export async function runText(
   env: Env,
   system: string,
   user: string,
-  maxTokens = 4096
+  maxTokens = 4096,
+  model?: string
 ): Promise<string> {
   if (!env.AI) throw new Error("Workers AI binding (AI) not configured");
-  const out = (await env.AI.run(cfModel(env), {
+  const out = (await env.AI.run(model || cfModel(env), {
     messages: [
       { role: "system", content: system },
       { role: "user", content: user },
@@ -47,7 +65,7 @@ const CLASSIFY_SYSTEM = `You analyze MS Paint drawing prompts. Return ONLY JSON:
 export async function classifyPrompt(env: Env, prompt: string): Promise<Classification> {
   const fallback: Classification = { category: "general", subcategories: [], tools: [] };
   try {
-    const text = await runText(env, CLASSIFY_SYSTEM, prompt, 256);
+    const text = await runText(env, CLASSIFY_SYSTEM, prompt, 256, UTILITY_MODEL);
     const parsed = extractJson<Partial<Classification>>(text);
     if (!parsed) return fallback;
     return {

--- a/website-next/functions/_lib/workers-ai.ts
+++ b/website-next/functions/_lib/workers-ai.ts
@@ -1,0 +1,61 @@
+/**
+ * Cloudflare Workers AI client — the free-tier drawing brain.
+ * Uses a cheap Llama text model to emit paint-command JSON, keeping the
+ * command/playback animation identical to the paid Anthropic path.
+ */
+
+import type { Env } from "./env";
+import { DEFAULT_CF_MODEL } from "./env";
+import { extractJson } from "./cta";
+
+interface CfTextResult {
+  response?: string;
+}
+
+export function cfModel(env: Env): string {
+  return env.CF_TEXT_MODEL || DEFAULT_CF_MODEL;
+}
+
+/** Run a text model with a system + user message. Returns raw text. */
+export async function runText(
+  env: Env,
+  system: string,
+  user: string,
+  maxTokens = 4096
+): Promise<string> {
+  if (!env.AI) throw new Error("Workers AI binding (AI) not configured");
+  const out = (await env.AI.run(cfModel(env), {
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    max_tokens: maxTokens,
+  })) as CfTextResult;
+  return out.response || "";
+}
+
+export interface Classification {
+  category: string;
+  subcategories: string[];
+  tools: string[];
+}
+
+const CLASSIFY_SYSTEM = `You analyze MS Paint drawing prompts. Return ONLY JSON:
+{"category":"one of: characters, animals, landscape, architecture, objects, vehicles, text_art, abstract, scene","subcategories":["1-3 compositional aspects"],"tools":["3-5 of: pencil,brush,airbrush,fill,line,curve,rectangle,ellipse,polygon,roundedRectangle,text,gradient"]}`;
+
+/** Situation assessment (ACTA pattern recognition). Degrades gracefully. */
+export async function classifyPrompt(env: Env, prompt: string): Promise<Classification> {
+  const fallback: Classification = { category: "general", subcategories: [], tools: [] };
+  try {
+    const text = await runText(env, CLASSIFY_SYSTEM, prompt, 256);
+    const parsed = extractJson<Partial<Classification>>(text);
+    if (!parsed) return fallback;
+    return {
+      category: parsed.category || "general",
+      subcategories: Array.isArray(parsed.subcategories) ? parsed.subcategories : [],
+      tools: Array.isArray(parsed.tools) ? parsed.tools : [],
+    };
+  } catch {
+    return fallback;
+  }
+}

--- a/website-next/functions/_lib/workers-ai.ts
+++ b/website-next/functions/_lib/workers-ai.ts
@@ -83,6 +83,35 @@ export async function runText(
   return extractModelText(out);
 }
 
+/**
+ * Run a vision-capable chat model with one or more images (data URLs) plus
+ * text. Uses the OpenAI-style multimodal content array supported by Workers AI
+ * multimodal chat models (Kimi K2.7, Llama 4 Scout).
+ */
+export async function runVision(
+  env: Env,
+  system: string,
+  user: string,
+  images: string[],
+  maxTokens = 4096,
+  model?: string
+): Promise<string> {
+  if (!env.AI) throw new Error("Workers AI binding (AI) not configured");
+  const id = model || cfModel(env);
+  const content: Array<Record<string, unknown>> = [{ type: "text", text: user }];
+  for (const url of images) {
+    if (url) content.push({ type: "image_url", image_url: { url } });
+  }
+  const out = await env.AI.run(id, {
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content },
+    ],
+    max_tokens: maxTokens,
+  });
+  return extractModelText(out);
+}
+
 export interface Classification {
   category: string;
   subcategories: string[];

--- a/website-next/functions/_lib/workers-ai.ts
+++ b/website-next/functions/_lib/workers-ai.ts
@@ -7,10 +7,35 @@
 import type { Env } from "./env";
 import { extractJson } from "./cta";
 import { getConfig, CONFIG_MODEL_KEY } from "./db";
-import { RECOMMENDED_MODEL, isAllowedModel } from "./models";
+import { RECOMMENDED_MODEL, isAllowedModel, modelApi } from "./models";
 
-interface CfTextResult {
-  response?: string;
+/** Pull assistant text out of whatever shape a Workers AI model returns. */
+function extractModelText(out: unknown): string {
+  if (typeof out === "string") return out;
+  if (!out || typeof out !== "object") return "";
+  const o = out as Record<string, unknown>;
+  // Chat models: { response: "..." }
+  if (typeof o.response === "string") return o.response;
+  // gpt-oss / Responses API: { output_text } or { output: [{ content:[{text}] }] }
+  if (typeof o.output_text === "string") return o.output_text;
+  if (Array.isArray(o.output)) {
+    const parts: string[] = [];
+    for (const item of o.output as Array<Record<string, unknown>>) {
+      const content = item?.content;
+      if (Array.isArray(content)) {
+        for (const c of content as Array<Record<string, unknown>>) {
+          if (typeof c?.text === "string") parts.push(c.text);
+        }
+      } else if (typeof item?.text === "string") {
+        parts.push(item.text as string);
+      }
+    }
+    if (parts.length) return parts.join("");
+  }
+  // Nested { result: { response } }
+  const result = o.result as Record<string, unknown> | undefined;
+  if (result && typeof result.response === "string") return result.response;
+  return "";
 }
 
 /** Synchronous fallback model (env var or recommended default). */
@@ -42,14 +67,20 @@ export async function runText(
   model?: string
 ): Promise<string> {
   if (!env.AI) throw new Error("Workers AI binding (AI) not configured");
-  const out = (await env.AI.run(model || cfModel(env), {
-    messages: [
-      { role: "system", content: system },
-      { role: "user", content: user },
-    ],
-    max_tokens: maxTokens,
-  })) as CfTextResult;
-  return out.response || "";
+  const id = model || cfModel(env);
+  // gpt-oss uses the Responses API (instructions + input); everyone else chat.
+  const input =
+    modelApi(id) === "responses"
+      ? { instructions: system, input: user, max_tokens: maxTokens }
+      : {
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          max_tokens: maxTokens,
+        };
+  const out = await env.AI.run(id, input);
+  return extractModelText(out);
 }
 
 export interface Classification {

--- a/website-next/functions/_lib/workers-ai.ts
+++ b/website-next/functions/_lib/workers-ai.ts
@@ -38,6 +38,75 @@ function extractModelText(out: unknown): string {
   return "";
 }
 
+/** A model's answer split into its visible output and its reasoning trace. */
+export interface ModelResult {
+  /** The answer text with any reasoning trace removed (safe to JSON-parse). */
+  text: string;
+  /** The concurrent chain-of-thought, if the model emitted one. */
+  reasoning: string | null;
+}
+
+/**
+ * Separate a reasoning model's chain-of-thought from its answer.
+ *
+ * Reasoning models (qwen3, QwQ, gpt-oss) emit their thinking inline as
+ * <think>…</think> before the JSON. Left in place it (a) wastes the shared
+ * token budget and truncates the command list, and (b) breaks the greedy
+ * extractJson match. We pull it OUT here so the answer parses cleanly AND so
+ * the trace can be fed to the reflection pass instead of being discarded.
+ */
+export function splitReasoning(raw: string): { text: string; reasoning: string | null } {
+  const TAG = /<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/gi;
+  const blocks = [...raw.matchAll(TAG)].map((m) => m[1].trim()).filter(Boolean);
+  if (blocks.length) {
+    return { text: raw.replace(TAG, "").trim(), reasoning: blocks.join("\n\n") || null };
+  }
+  // Truncated trace: an opening <think> with no closing tag (budget ran out
+  // mid-thought). Treat everything after it as reasoning, keep prior text.
+  const open = raw.search(/<think(?:ing)?>/i);
+  if (open !== -1) {
+    const before = raw.slice(0, open).trim();
+    const after = raw.slice(open).replace(/<\/?think(?:ing)?>/gi, "").trim();
+    return { text: before, reasoning: after || null };
+  }
+  return { text: raw, reasoning: null };
+}
+
+/** Pull a dedicated reasoning field out of a Workers AI response, if present. */
+function extractModelReasoning(out: unknown): string | null {
+  if (!out || typeof out !== "object") return null;
+  const o = out as Record<string, unknown>;
+  // Chat models that expose reasoning separately.
+  for (const key of ["reasoning_content", "reasoning"]) {
+    const v = o[key];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  // Responses API: output items of type "reasoning".
+  if (Array.isArray(o.output)) {
+    const parts: string[] = [];
+    for (const item of o.output as Array<Record<string, unknown>>) {
+      if (item?.type !== "reasoning") continue;
+      const c = (item.content ?? item.summary) as unknown;
+      if (Array.isArray(c)) {
+        for (const x of c as Array<Record<string, unknown>>) {
+          if (typeof x?.text === "string") parts.push(x.text);
+        }
+      } else if (typeof item.text === "string") {
+        parts.push(item.text as string);
+      }
+    }
+    if (parts.length) return parts.join("\n").trim();
+  }
+  return null;
+}
+
+/** Combine a dedicated reasoning field and any inline <think> trace. */
+function unpack(out: unknown): ModelResult {
+  const fieldReasoning = extractModelReasoning(out);
+  const { text, reasoning: inlineReasoning } = splitReasoning(extractModelText(out));
+  return { text, reasoning: fieldReasoning || inlineReasoning };
+}
+
 /** Synchronous fallback model (env var or recommended default). */
 export function cfModel(env: Env): string {
   const fromEnv = env.CF_TEXT_MODEL;
@@ -55,17 +124,25 @@ export async function resolveDrawModel(env: Env): Promise<string> {
   return cfModel(env);
 }
 
-/** Cheap, fixed model for utility passes (classification, reflection). */
-export const UTILITY_MODEL = RECOMMENDED_MODEL;
+/**
+ * Cheap, fixed model for utility passes (classification, reflection).
+ * Must be a NON-reasoning instruct model that emits strict JSON reliably:
+ * these passes parse the output directly, so a model that wraps answers in a
+ * reasoning trace (or fumbles JSON) silently drops classifications/lessons.
+ */
+export const UTILITY_MODEL = "@cf/meta/llama-3.1-8b-instruct-fp8";
 
-/** Run a text model with a system + user message. Returns raw text. */
-export async function runText(
+/**
+ * Run a text model, returning BOTH the answer (reasoning stripped) and the
+ * reasoning trace. Use this when you want to keep the chain-of-thought.
+ */
+export async function runTextRich(
   env: Env,
   system: string,
   user: string,
   maxTokens = 4096,
   model?: string
-): Promise<string> {
+): Promise<ModelResult> {
   if (!env.AI) throw new Error("Workers AI binding (AI) not configured");
   const id = model || cfModel(env);
   // gpt-oss uses the Responses API (instructions + input); everyone else chat.
@@ -79,8 +156,18 @@ export async function runText(
           ],
           max_tokens: maxTokens,
         };
-  const out = await env.AI.run(id, input);
-  return extractModelText(out);
+  return unpack(await env.AI.run(id, input));
+}
+
+/** Run a text model with a system + user message. Returns answer text only. */
+export async function runText(
+  env: Env,
+  system: string,
+  user: string,
+  maxTokens = 4096,
+  model?: string
+): Promise<string> {
+  return (await runTextRich(env, system, user, maxTokens, model)).text;
 }
 
 /**
@@ -88,6 +175,32 @@ export async function runText(
  * text. Uses the OpenAI-style multimodal content array supported by Workers AI
  * multimodal chat models (Kimi K2.7, Llama 4 Scout).
  */
+export async function runVisionRich(
+  env: Env,
+  system: string,
+  user: string,
+  images: string[],
+  maxTokens = 4096,
+  model?: string
+): Promise<ModelResult> {
+  if (!env.AI) throw new Error("Workers AI binding (AI) not configured");
+  const id = model || cfModel(env);
+  const content: Array<Record<string, unknown>> = [{ type: "text", text: user }];
+  for (const url of images) {
+    if (url) content.push({ type: "image_url", image_url: { url } });
+  }
+  return unpack(
+    await env.AI.run(id, {
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content },
+      ],
+      max_tokens: maxTokens,
+    })
+  );
+}
+
+/** Vision variant of {@link runText}. Returns answer text only. */
 export async function runVision(
   env: Env,
   system: string,
@@ -96,20 +209,7 @@ export async function runVision(
   maxTokens = 4096,
   model?: string
 ): Promise<string> {
-  if (!env.AI) throw new Error("Workers AI binding (AI) not configured");
-  const id = model || cfModel(env);
-  const content: Array<Record<string, unknown>> = [{ type: "text", text: user }];
-  for (const url of images) {
-    if (url) content.push({ type: "image_url", image_url: { url } });
-  }
-  const out = await env.AI.run(id, {
-    messages: [
-      { role: "system", content: system },
-      { role: "user", content },
-    ],
-    max_tokens: maxTokens,
-  });
-  return extractModelText(out);
+  return (await runVisionRich(env, system, user, images, maxTokens, model)).text;
 }
 
 export interface Classification {

--- a/website-next/functions/api/admin/[[path]].ts
+++ b/website-next/functions/api/admin/[[path]].ts
@@ -12,6 +12,9 @@
  */
 
 import type { Env } from "../../_lib/env";
+import { setConfig, CONFIG_MODEL_KEY } from "../../_lib/db";
+import { resolveDrawModel } from "../../_lib/workers-ai";
+import { MODEL_CATALOG, isAllowedModel, modelInfo } from "../../_lib/models";
 
 function timingSafeEqual(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
@@ -37,6 +40,37 @@ const json = (data: unknown, status = 200) =>
     headers: { "Content-Type": "application/json" },
   });
 
+// --- Set the active free-tier drawing model -------------------------------
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  if (!authorized(request, env)) return deny();
+
+  const url = new URL(request.url);
+  const parts = (context.params.path as string[] | undefined) || [];
+  if ((parts[0] || "") !== "model") return new Response("Not found", { status: 404 });
+
+  const ct = request.headers.get("Content-Type") || "";
+  let model = "";
+  if (ct.includes("application/json")) {
+    const b = (await request.json()) as { model?: string };
+    model = b.model || "";
+  } else {
+    const form = await request.formData();
+    model = String(form.get("model") || "");
+  }
+
+  if (!isAllowedModel(model)) return json({ error: "Model not in catalog" }, 400);
+  await setConfig(env, CONFIG_MODEL_KEY, model);
+
+  // JSON callers get JSON; HTML form submits redirect back to the gallery.
+  if (ct.includes("application/json")) return json({ ok: true, model });
+  const token = url.searchParams.get("token") || "";
+  return new Response(null, {
+    status: 303,
+    headers: { Location: `/api/admin?token=${encodeURIComponent(token)}` },
+  });
+};
+
 export const onRequestGet: PagesFunction<Env> = async (context) => {
   const { request, env } = context;
   if (!authorized(request, env)) return deny();
@@ -56,6 +90,12 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     return new Response(obj.body, {
       headers: { "Content-Type": "image/png", "Cache-Control": "private, max-age=60" },
     });
+  }
+
+  // --- Model catalog + current selection (JSON) ---------------------------
+  if (sub === "models") {
+    const active = await resolveDrawModel(env);
+    return json({ active, catalog: MODEL_CATALOG });
   }
 
   // --- Aggregate stats ----------------------------------------------------
@@ -105,6 +145,9 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
        (SELECT COUNT(*) FROM lessons) AS lessons`
   ).first<Record<string, number>>();
 
+  const activeModel = await resolveDrawModel(env);
+  const activeInfo = modelInfo(activeModel);
+
   const esc = (s: unknown) =>
     String(s ?? "")
       .replace(/&/g, "&amp;")
@@ -127,7 +170,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         <div class="thumb">${img ? `<img loading="lazy" src="${img}" alt="">` : `<div class="noimg">${cmds} cmds<br>(no render)</div>`}</div>
         <div class="meta">
           <div class="prompt">${esc(g.prompt)}</div>
-          <div class="tags"><span class="tag ${g.provider}">${esc(g.provider)}</span><span class="tag">${esc(g.category)}</span><span class="tag">${cmds} cmds</span></div>
+          <div class="tags"><span class="tag ${g.provider}">${esc(g.provider)}</span><span class="tag">${esc(g.category)}</span><span class="tag">${cmds} cmds</span><span class="tag" title="${esc(g.model)}">${esc(modelInfo(String(g.model))?.label || g.model)}</span></div>
           ${g.description ? `<div class="desc">${esc(g.description)}</div>` : ""}
           ${g.cues_and_strategies ? `<div class="lesson"><b>lesson:</b> ${esc(g.cues_and_strategies)}</div>` : ""}
           ${g.do_differently ? `<div class="lesson"><b>next time:</b> ${esc(g.do_differently)}</div>` : ""}
@@ -136,6 +179,33 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       </div>`;
     })
     .join("\n");
+
+  const modelRows = MODEL_CATALOG.map((m) => {
+    const active = m.id === activeModel;
+    return `<tr class="${active ? "active" : ""}">
+      <td><input type="radio" name="model" value="${esc(m.id)}" ${active ? "checked" : ""}></td>
+      <td><b>${esc(m.label)}</b>${m.recommended ? ' <span class="rec">★ recommended</span>' : ""}${active ? ' <span class="cur">● in use</span>' : ""}<br><code>${esc(m.id)}</code></td>
+      <td class="num">$${m.inPrice.toFixed(3)}</td>
+      <td class="num">$${m.outPrice.toFixed(3)}</td>
+      <td class="num">~${esc(m.perDrawing)}</td>
+      <td class="note">${esc(m.note)}</td>
+    </tr>`;
+  }).join("");
+
+  const modelPanel = `<form class="models" method="post" action="/api/admin/model?token=${t}">
+    <div class="mhead">
+      <span>🧠 Drawing model</span>
+      <span class="active">in use: <b>${esc(activeInfo?.label || activeModel)}</b> — <code>${esc(activeModel)}</code>${activeInfo ? ` · ~${esc(activeInfo.perDrawing)}/drawing` : ""}</span>
+    </div>
+    <table>
+      <thead><tr><th></th><th>model</th><th>$/M in</th><th>$/M out</th><th>~$/draw</th><th>notes</th></tr></thead>
+      <tbody>${modelRows}</tbody>
+    </table>
+    <div class="mfoot">
+      <button type="submit">Set drawing model</button>
+      <span class="hint">Free-tier drawings only. Classification &amp; reflection always use the cheap recommended model. ~$/draw assumes ~1.5K in / 2.5K out tokens. Bring-your-own-key users are unaffected.</span>
+    </div>
+  </form>`;
 
   const html = `<!doctype html><html><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -158,14 +228,33 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   .desc{color:#333;font-size:12px;margin-bottom:4px}
   .lesson{background:#ffffcc;border:1px solid #808080;padding:2px 4px;font-size:11px;margin-top:3px}
   .when{color:#404040;font-size:10px;margin-top:4px}
+  .models{margin:12px;background:#c0c0c0;border:2px outset #fff;padding:8px}
+  .models .mhead{display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap;align-items:center;font-weight:bold;margin-bottom:8px}
+  .models .active{font-weight:normal;background:#000080;color:#fff;padding:3px 8px;border:2px inset #fff}
+  .models .active code{color:#9fd}
+  .models table{width:100%;border-collapse:collapse;background:#fff;border:2px inset #fff}
+  .models th,.models td{border:1px solid #c0c0c0;padding:4px 6px;text-align:left;font-size:12px;vertical-align:top}
+  .models th{background:#000080;color:#fff;font-size:11px}
+  .models td.num{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
+  .models td.note{color:#333;font-size:11px}
+  .models tr.active{background:#ffffcc}
+  .models code{font-family:"Courier New",monospace;font-size:11px;color:#000080}
+  .models .rec{color:#008000;font-size:11px}
+  .models .cur{color:#000080;font-size:11px}
+  .models .mfoot{margin-top:8px;display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+  .models button{background:#c0c0c0;border:2px outset #fff;padding:4px 14px;font-weight:bold;cursor:pointer;font-family:inherit}
+  .models button:active{border-style:inset}
+  .models .hint{color:#404040;font-size:10px;flex:1;min-width:200px}
 </style></head><body>
 <header>
   <span>🎨 MSPaint Admin</span>
   <span class="stat">${stats?.users ?? 0} users</span>
   <span class="stat">${stats?.generations ?? 0} drawings</span>
   <span class="stat">${stats?.lessons ?? 0} lessons accrued</span>
+  <span class="stat">model: ${esc(activeInfo?.label || activeModel)}</span>
   <span class="stat">showing latest ${gens.results?.length ?? 0}</span>
 </header>
+${modelPanel}
 <div class="grid">${cards || "<p style='padding:12px'>No drawings yet.</p>"}</div>
 </body></html>`;
 

--- a/website-next/functions/api/admin/[[path]].ts
+++ b/website-next/functions/api/admin/[[path]].ts
@@ -1,0 +1,173 @@
+/**
+ * Erich-only admin console for the MS Paint logs.
+ *
+ * Gated by the ADMIN_TOKEN secret (set via `wrangler pages secret put ADMIN_TOKEN`).
+ * Pass it as ?token=... or an X-Admin-Token header.
+ *
+ * Routes (all under /api/admin):
+ *   GET  /api/admin            -> HTML gallery of all drawings + lessons
+ *   GET  /api/admin/data       -> JSON: generations (with lessons), paginated
+ *   GET  /api/admin/stats      -> JSON: aggregate stats
+ *   GET  /api/admin/image?key= -> streams a drawing PNG from R2
+ */
+
+import type { Env } from "../../_lib/env";
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+function authorized(request: Request, env: Env): boolean {
+  const expected = env.ADMIN_TOKEN;
+  if (!expected) return false;
+  const url = new URL(request.url);
+  const provided = url.searchParams.get("token") || request.headers.get("X-Admin-Token") || "";
+  return timingSafeEqual(provided, expected);
+}
+
+const deny = () =>
+  new Response("Forbidden", { status: 403, headers: { "Content-Type": "text/plain" } });
+
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  if (!authorized(request, env)) return deny();
+
+  const url = new URL(request.url);
+  const parts = (context.params.path as string[] | undefined) || [];
+  const sub = parts[0] || "";
+
+  if (!env.MSPAINT_DB) return json({ error: "MSPAINT_DB not bound" }, 500);
+
+  // --- Stream a drawing image from R2 -------------------------------------
+  if (sub === "image") {
+    const key = url.searchParams.get("key");
+    if (!key || !env.MSPAINT_BUCKET) return new Response("Not found", { status: 404 });
+    const obj = await env.MSPAINT_BUCKET.get(key);
+    if (!obj) return new Response("Not found", { status: 404 });
+    return new Response(obj.body, {
+      headers: { "Content-Type": "image/png", "Cache-Control": "private, max-age=60" },
+    });
+  }
+
+  // --- Aggregate stats ----------------------------------------------------
+  if (sub === "stats") {
+    const totals = await env.MSPAINT_DB.prepare(
+      `SELECT
+         (SELECT COUNT(*) FROM users) AS users,
+         (SELECT COUNT(*) FROM generations) AS generations,
+         (SELECT COUNT(*) FROM generations WHERE provider='cloudflare') AS free_gens,
+         (SELECT COUNT(*) FROM generations WHERE provider='anthropic') AS paid_gens,
+         (SELECT COUNT(*) FROM lessons) AS lessons,
+         (SELECT SUM(free_uses_used) FROM users) AS total_free_used`
+    ).first();
+    const byCategory = await env.MSPAINT_DB.prepare(
+      `SELECT category, COUNT(*) AS n FROM generations GROUP BY category ORDER BY n DESC`
+    ).all();
+    return json({ totals, byCategory: byCategory.results });
+  }
+
+  // --- JSON data feed -----------------------------------------------------
+  if (sub === "data") {
+    const limit = Math.min(200, parseInt(url.searchParams.get("limit") || "50", 10) || 50);
+    const offset = parseInt(url.searchParams.get("offset") || "0", 10) || 0;
+    const gens = await env.MSPAINT_DB.prepare(
+      `SELECT * FROM generations ORDER BY created_at DESC LIMIT ? OFFSET ?`
+    )
+      .bind(limit, offset)
+      .all();
+    return json({ generations: gens.results });
+  }
+
+  // --- HTML gallery (default) --------------------------------------------
+  const limit = Math.min(200, parseInt(url.searchParams.get("limit") || "60", 10) || 60);
+  const token = url.searchParams.get("token") || "";
+  const gens = await env.MSPAINT_DB.prepare(
+    `SELECT g.*, l.difficult_element, l.cues_and_strategies, l.do_differently
+       FROM generations g
+       LEFT JOIN lessons l ON l.generation_id = g.id
+      ORDER BY g.created_at DESC LIMIT ?`
+  )
+    .bind(limit)
+    .all<Record<string, unknown>>();
+  const stats = await env.MSPAINT_DB.prepare(
+    `SELECT
+       (SELECT COUNT(*) FROM users) AS users,
+       (SELECT COUNT(*) FROM generations) AS generations,
+       (SELECT COUNT(*) FROM lessons) AS lessons`
+  ).first<Record<string, number>>();
+
+  const esc = (s: unknown) =>
+    String(s ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  const t = encodeURIComponent(token);
+
+  const cards = (gens.results || [])
+    .map((g) => {
+      const after = g.canvas_after_key
+        ? `/api/admin/image?token=${t}&key=${encodeURIComponent(String(g.canvas_after_key))}`
+        : null;
+      const before = g.canvas_before_key
+        ? `/api/admin/image?token=${t}&key=${encodeURIComponent(String(g.canvas_before_key))}`
+        : null;
+      const img = after || before;
+      const cmds = Number(g.command_count) || 0;
+      return `<div class="card">
+        <div class="thumb">${img ? `<img loading="lazy" src="${img}" alt="">` : `<div class="noimg">${cmds} cmds<br>(no render)</div>`}</div>
+        <div class="meta">
+          <div class="prompt">${esc(g.prompt)}</div>
+          <div class="tags"><span class="tag ${g.provider}">${esc(g.provider)}</span><span class="tag">${esc(g.category)}</span><span class="tag">${cmds} cmds</span></div>
+          ${g.description ? `<div class="desc">${esc(g.description)}</div>` : ""}
+          ${g.cues_and_strategies ? `<div class="lesson"><b>lesson:</b> ${esc(g.cues_and_strategies)}</div>` : ""}
+          ${g.do_differently ? `<div class="lesson"><b>next time:</b> ${esc(g.do_differently)}</div>` : ""}
+          <div class="when">${esc(g.created_at)} · ${esc(String(g.cookie_uuid).slice(0, 8))}</div>
+        </div>
+      </div>`;
+    })
+    .join("\n");
+
+  const html = `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MSPaint Admin · Some Claude Skills</title>
+<style>
+  body{margin:0;background:#008080;color:#000;font:13px/1.4 "MS Sans Serif",Tahoma,system-ui,sans-serif}
+  header{background:#000080;color:#fff;padding:8px 12px;font-weight:bold;display:flex;gap:16px;align-items:center;flex-wrap:wrap}
+  header .stat{background:#c0c0c0;color:#000;padding:2px 8px;border:2px outset #fff;font-weight:normal}
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:10px;padding:12px}
+  .card{background:#c0c0c0;border:2px outset #fff;padding:6px}
+  .thumb{background:#fff;border:2px inset #fff;aspect-ratio:4/3;display:flex;align-items:center;justify-content:center;overflow:hidden}
+  .thumb img{width:100%;height:100%;object-fit:contain;image-rendering:pixelated}
+  .noimg{color:#808080;text-align:center;font-size:11px}
+  .meta{margin-top:6px}
+  .prompt{font-weight:bold;margin-bottom:4px;word-break:break-word}
+  .tags{display:flex;gap:4px;flex-wrap:wrap;margin-bottom:4px}
+  .tag{background:#fff;border:1px solid #808080;padding:0 4px;font-size:11px}
+  .tag.cloudflare{background:#f6821f;color:#fff}
+  .tag.anthropic{background:#d97757;color:#fff}
+  .desc{color:#333;font-size:12px;margin-bottom:4px}
+  .lesson{background:#ffffcc;border:1px solid #808080;padding:2px 4px;font-size:11px;margin-top:3px}
+  .when{color:#404040;font-size:10px;margin-top:4px}
+</style></head><body>
+<header>
+  <span>🎨 MSPaint Admin</span>
+  <span class="stat">${stats?.users ?? 0} users</span>
+  <span class="stat">${stats?.generations ?? 0} drawings</span>
+  <span class="stat">${stats?.lessons ?? 0} lessons accrued</span>
+  <span class="stat">showing latest ${gens.results?.length ?? 0}</span>
+</header>
+<div class="grid">${cards || "<p style='padding:12px'>No drawings yet.</p>"}</div>
+</body></html>`;
+
+  return new Response(html, { status: 200, headers: { "Content-Type": "text/html; charset=utf-8" } });
+};

--- a/website-next/functions/api/admin/[[path]].ts
+++ b/website-next/functions/api/admin/[[path]].ts
@@ -22,16 +22,29 @@ import {
   incrementBatch,
   listLessonCategories,
   getLessons,
+  getFlags,
+  setFlags,
+  type FeatureFlags,
+  recordEvent,
+  getEvents,
+  getGeneration,
+  updateGenerationFinal,
 } from "../../_lib/db";
-import { resolveDrawModel, runText, classifyPrompt, UTILITY_MODEL } from "../../_lib/workers-ai";
+import { resolveDrawModel, runText, runVision, classifyPrompt, UTILITY_MODEL } from "../../_lib/workers-ai";
 import {
   buildDrawSystemPrompt,
+  buildContinuePrompt,
+  buildContinueUserContent,
   renderWisdom,
   REFLECTION_SYSTEM_PROMPT,
   buildReflectionUserContent,
+  CRITIQUE_VISION_SYSTEM,
+  buildCritiqueUserContent,
   extractJson,
 } from "../../_lib/cta";
-import { MODEL_CATALOG, isAllowedModel, modelInfo } from "../../_lib/models";
+import { MODEL_CATALOG, isAllowedModel, modelInfo, hasVision, VISION_CRITIC_MODEL } from "../../_lib/models";
+import { searchReferences } from "../../_lib/references";
+import { storePng, storeDataUrl } from "../../_lib/r2";
 
 function timingSafeEqual(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
@@ -86,7 +99,20 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     });
   }
 
-  // --- Run ONE drawing iteration (the soak-test unit) ---------------------
+  // --- Set public feature flags (what non-admins get) ---------------------
+  if (sub === "flags") {
+    const f = (await request.json()) as Partial<FeatureFlags>;
+    const next: FeatureFlags = {
+      references: !!f.references,
+      critique: !!f.critique,
+      iterative: !!f.iterative,
+      maxTurns: Math.max(1, Math.min(6, Number(f.maxTurns) || 1)),
+    };
+    await setFlags(env, next);
+    return json({ ok: true, flags: next });
+  }
+
+  // --- Run the FIRST drawing pass (the soak-test unit) --------------------
   if (sub === "run") {
     if (!env.AI || !env.MSPAINT_DB) return json({ error: "AI/DB not bound" }, 500);
     const started = Date.now();
@@ -96,138 +122,212 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       batchId?: string;
       index?: number;
       total?: number;
+      references?: boolean;
+      reflect?: boolean; // text reflection (skip if a vision critique will run)
     };
     const model = b.model && isAllowedModel(b.model) ? b.model : "";
     const prompt = (b.prompt || "").trim();
     if (!model) return json({ error: "Unknown model" }, 400);
     if (!prompt) return json({ error: "Prompt required" }, 400);
 
-    // First iteration opens the batch record.
     if (b.batchId && (b.index || 0) === 0) {
       await createBatch(env, { id: b.batchId, model, prompt, target: b.total || 1 }).catch(() => {});
     }
 
-    // 1. Situation assessment (cheap).
+    const generationId = crypto.randomUUID();
+    const wantRefs = !!b.references && hasVision(model);
+
+    // 1. Situation assessment.
     const cls = await classifyPrompt(env, prompt).catch(() => ({
       category: "general",
       subcategories: [] as string[],
       tools: [] as string[],
     }));
+    await recordEvent(env, { generationId, batchId: b.batchId, seq: 0, phase: "assess", type: "classification", data: cls });
 
-    // 2. Recall accrued wisdom — capture exactly what the agent will see.
+    // 2. References — "summon and look at" reference photos (vision only).
+    const refImages: string[] = [];
+    const refUrls: string[] = [];
+    const refKeys: string[] = [];
+    if (wantRefs) {
+      const { images, query } = await searchReferences(env, prompt, 1);
+      await recordEvent(env, { generationId, batchId: b.batchId, seq: 1, phase: "search", type: "reference_query", data: { query } });
+      for (let i = 0; i < images.length; i++) {
+        refImages.push(images[i].dataUrl);
+        refUrls.push(images[i].url);
+        const key = await storeDataUrl(env, `drawings/${generationId}/ref${i}.jpg`, images[i].dataUrl);
+        if (key) refKeys.push(key);
+        await recordEvent(env, { generationId, batchId: b.batchId, seq: 2, phase: "look", type: "reference_image", data: { url: images[i].url, key, photographer: images[i].photographer } });
+      }
+    }
+
+    // 3. Recall accrued wisdom.
     const wisdom = await retrieveWisdom(env, cls.category, 4);
     const wisdomShown = renderWisdom(wisdom);
     const drawSystem = buildDrawSystemPrompt(wisdom);
 
-    // 3. Draw with the chosen (premium) model.
+    // 4. Draw (vision if we have references, else text).
     let raw = "";
     let parseOk = true;
+    let needsAnotherTurn = false;
     let draw: { thinking: string | null; plan: unknown; description: string; commands: unknown[] } | null = null;
     try {
-      raw = await runText(env, drawSystem, prompt, 4096, model);
-      const p = extractJson<{ thinking?: string; plan?: unknown; description?: string; commands?: unknown[] }>(raw);
+      raw = refImages.length
+        ? await runVision(env, drawSystem, prompt, refImages, 4096, model)
+        : await runText(env, drawSystem, prompt, 4096, model);
+      const p = extractJson<{ thinking?: string; plan?: unknown; description?: string; commands?: unknown[]; needsAnotherTurn?: boolean }>(raw);
       if (p && Array.isArray(p.commands)) {
-        draw = {
-          thinking: p.thinking ?? null,
-          plan: p.plan ?? null,
-          description: p.description || "Drawing",
-          commands: p.commands,
-        };
-      } else {
-        parseOk = false;
-      }
+        draw = { thinking: p.thinking ?? null, plan: p.plan ?? null, description: p.description || "Drawing", commands: p.commands };
+        needsAnotherTurn = !!p.needsAnotherTurn;
+      } else parseOk = false;
     } catch (e) {
       parseOk = false;
       raw = e instanceof Error ? e.message : "error";
     }
 
-    const generationId = crypto.randomUUID();
     const latencyMs = Date.now() - started;
-    const adminIdentity = {
-      cookieUuid: "admin-batch",
-      ipUaHash: "admin",
-      isNewCookie: false,
-      country: null,
-      userAgent: "admin-batch",
-    };
+    const adminIdentity = { cookieUuid: "admin-batch", ipUaHash: "admin", isNewCookie: false, country: null, userAgent: "admin-batch" };
 
     await recordGeneration(env, {
-      id: generationId,
-      userId: "admin-batch",
-      identity: adminIdentity,
-      provider: "batch",
-      model,
-      prompt,
-      category: cls.category,
-      subcategories: cls.subcategories,
-      recommendedTools: cls.tools,
-      thinking: draw?.thinking,
-      plan: draw?.plan,
-      description: draw?.description,
-      commands: draw?.commands,
-      commandCount: draw?.commands.length,
-      latencyMs,
-      status: parseOk ? "ok" : "error",
-      error: parseOk ? null : "parse_failed",
-      batchId: b.batchId ?? null,
+      id: generationId, userId: "admin-batch", identity: adminIdentity, provider: "batch", model, prompt,
+      category: cls.category, subcategories: cls.subcategories, recommendedTools: cls.tools,
+      referenceQuery: wantRefs ? searchReferences.name : null,
+      thinking: draw?.thinking, plan: draw?.plan, description: draw?.description,
+      commands: draw?.commands, commandCount: draw?.commands.length, latencyMs,
+      status: parseOk ? "ok" : "error", error: parseOk ? null : "parse_failed", batchId: b.batchId ?? null,
     }).catch(() => {});
+    if (refKeys.length) await updateGenerationFinal(env, generationId, { referenceKeys: refKeys }).catch(() => {});
+    if (draw) await recordEvent(env, { generationId, batchId: b.batchId, seq: 3, phase: "plan", type: "plan", data: { plan: draw.plan, thinking: draw.thinking } }).catch(() => {});
+    await recordEvent(env, { generationId, batchId: b.batchId, seq: 4, phase: "draw", type: "commands", data: { pass: 0, commandCount: draw?.commands.length ?? 0, commands: draw?.commands ?? [], needsAnotherTurn } }).catch(() => {});
 
-    // 4. Reflection (cheap utility model) — accrue a lesson, awaited so the
-    //    next iteration can immediately recall it.
+    // 5. Text reflection (unless caller will run a vision critique instead).
     let lesson: Record<string, unknown> | null = null;
-    if (parseOk && draw) {
-      try {
-        const text = await runText(
-          env,
-          REFLECTION_SYSTEM_PROMPT,
-          buildReflectionUserContent(prompt, cls.category, draw.description, draw.commands.length),
-          700,
-          UTILITY_MODEL
-        );
-        const ref = extractJson<Record<string, unknown>>(text);
-        if (ref) {
-          await recordLesson(env, {
-            id: crypto.randomUUID(),
-            generationId,
-            category: cls.category,
-            subcategories: cls.subcategories,
-            difficultElement: (ref.difficultElement as string) ?? null,
-            whyDifficult: (ref.whyDifficult as string) ?? null,
-            commonErrors: (ref.commonErrors as string) ?? null,
-            cuesAndStrategies: (ref.cuesAndStrategies as string) ?? null,
-            whatWorked: ref.whatWorked,
-            whatDidnt: ref.whatDidnt,
-            wishIKnew: (ref.wishIKnew as string) ?? null,
-            doDifferently: (ref.doDifferently as string) ?? null,
-            toolsNeeded: ref.toolsNeeded,
-          });
-          lesson = ref;
-        }
-      } catch {
-        /* reflection is best-effort */
-      }
+    if (parseOk && draw && b.reflect !== false) {
+      lesson = await reflectAndStore(env, generationId, prompt, cls.category, cls.subcategories, draw.description, draw.commands.length);
     }
 
     if (b.batchId) await incrementBatch(env, b.batchId, parseOk).catch(() => {});
 
     return json({
-      ok: parseOk,
-      generationId,
-      model,
-      category: cls.category,
-      latencyMs,
-      commandCount: draw?.commands.length ?? 0,
-      description: draw?.description ?? null,
-      commands: draw?.commands ?? [],
-      wisdomCount: wisdom.length,
-      wisdomShown, // exactly the "Lessons from artists past" text injected
-      lesson,
-      rawError: parseOk ? null : raw.slice(0, 300),
+      ok: parseOk, generationId, model, category: cls.category, subcategories: cls.subcategories,
+      latencyMs, commandCount: draw?.commands.length ?? 0, description: draw?.description ?? null,
+      commands: draw?.commands ?? [], needsAnotherTurn, references: refUrls,
+      wisdomCount: wisdom.length, wisdomShown, lesson, rawError: parseOk ? null : raw.slice(0, 300),
     });
+  }
+
+  // --- Continue drawing (look-as-you-go / "another turn") -----------------
+  if (sub === "continue") {
+    if (!env.AI || !env.MSPAINT_DB) return json({ error: "AI/DB not bound" }, 500);
+    const started = Date.now();
+    const b = (await request.json()) as {
+      generationId?: string; model?: string; prompt?: string; category?: string;
+      pass?: number; currentImage?: string;
+    };
+    const model = b.model && isAllowedModel(b.model) ? b.model : "";
+    if (!model || !hasVision(model)) return json({ error: "Continuation needs a vision model" }, 400);
+    if (!b.generationId || !b.currentImage || !b.prompt) return json({ error: "generationId, prompt, currentImage required" }, 400);
+    const pass = Math.max(1, Number(b.pass) || 1);
+
+    const wisdom = await retrieveWisdom(env, b.category || "general", 4);
+    await recordEvent(env, { generationId: b.generationId, seq: 10 * pass, phase: "look", type: "own_canvas", data: { pass } });
+
+    let parseOk = true, needsAnotherTurn = false;
+    let draw: { thinking: string | null; description: string; commands: unknown[] } | null = null;
+    let raw = "";
+    try {
+      raw = await runVision(env, buildContinuePrompt(wisdom), buildContinueUserContent(b.prompt, pass), [b.currentImage], 4096, model);
+      const p = extractJson<{ thinking?: string; description?: string; commands?: unknown[]; needsAnotherTurn?: boolean }>(raw);
+      if (p && Array.isArray(p.commands)) {
+        draw = { thinking: p.thinking ?? null, description: p.description || "continued", commands: p.commands };
+        needsAnotherTurn = !!p.needsAnotherTurn;
+      } else parseOk = false;
+    } catch (e) {
+      parseOk = false;
+      raw = e instanceof Error ? e.message : "error";
+    }
+    await recordEvent(env, { generationId: b.generationId, seq: 10 * pass + 1, phase: "draw", type: "commands", data: { pass, commandCount: draw?.commands.length ?? 0, commands: draw?.commands ?? [], needsAnotherTurn } }).catch(() => {});
+    return json({ ok: parseOk, commands: draw?.commands ?? [], needsAnotherTurn, description: draw?.description, latencyMs: Date.now() - started, rawError: parseOk ? null : raw.slice(0, 300) });
+  }
+
+  // --- Vision critique of the FINAL render --------------------------------
+  if (sub === "critique") {
+    if (!env.AI || !env.MSPAINT_DB) return json({ error: "AI/DB not bound" }, 500);
+    const b = (await request.json()) as {
+      generationId?: string; prompt?: string; image?: string; category?: string;
+      commandCount?: number; passCount?: number; model?: string;
+    };
+    if (!b.generationId || !b.image || !b.prompt) return json({ error: "generationId, prompt, image required" }, 400);
+    const critic = b.model && hasVision(b.model) ? b.model : VISION_CRITIC_MODEL;
+
+    let critique: Record<string, unknown> | null = null;
+    try {
+      const text = await runVision(env, CRITIQUE_VISION_SYSTEM, buildCritiqueUserContent(b.prompt, b.commandCount || 0), [b.image], 800, critic);
+      critique = extractJson<Record<string, unknown>>(text);
+    } catch {
+      /* best-effort */
+    }
+    if (critique) {
+      const score = Number(critique.aestheticScore);
+      await recordLesson(env, {
+        id: crypto.randomUUID(), generationId: b.generationId, category: b.category || "general",
+        difficultElement: (critique.difficultElement as string) ?? null,
+        whyDifficult: (critique.whyDifficult as string) ?? null,
+        commonErrors: (critique.commonErrors as string) ?? null,
+        cuesAndStrategies: (critique.cuesAndStrategies as string) ?? null,
+        whatWorked: critique.whatWorked, whatDidnt: critique.whatDidnt,
+        wishIKnew: (critique.wishIKnew as string) ?? null, doDifferently: (critique.doDifferently as string) ?? null,
+        toolsNeeded: critique.toolsNeeded, aestheticScore: Number.isFinite(score) ? score : null, sawImage: true,
+      }).catch(() => {});
+      await updateGenerationFinal(env, b.generationId, {
+        passCount: b.passCount, aestheticScore: Number.isFinite(score) ? score : null,
+        critique: JSON.stringify(critique),
+      }).catch(() => {});
+      await recordEvent(env, { generationId: b.generationId, seq: 9999, phase: "critique", type: "vision_critique", data: critique }).catch(() => {});
+    } else if (b.passCount) {
+      await updateGenerationFinal(env, b.generationId, { passCount: b.passCount }).catch(() => {});
+    }
+    return json({ ok: !!critique, critique, critic });
   }
 
   return new Response("Not found", { status: 404 });
 };
+
+/** Shared text reflection → lesson (returns the parsed reflection). */
+async function reflectAndStore(
+  env: Env,
+  generationId: string,
+  prompt: string,
+  category: string,
+  subcategories: string[],
+  description: string,
+  commandCount: number
+): Promise<Record<string, unknown> | null> {
+  try {
+    const text = await runText(
+      env,
+      REFLECTION_SYSTEM_PROMPT,
+      buildReflectionUserContent(prompt, category, description, commandCount),
+      700,
+      UTILITY_MODEL
+    );
+    const ref = extractJson<Record<string, unknown>>(text);
+    if (!ref) return null;
+    await recordLesson(env, {
+      id: crypto.randomUUID(), generationId, category, subcategories,
+      difficultElement: (ref.difficultElement as string) ?? null,
+      whyDifficult: (ref.whyDifficult as string) ?? null,
+      commonErrors: (ref.commonErrors as string) ?? null,
+      cuesAndStrategies: (ref.cuesAndStrategies as string) ?? null,
+      whatWorked: ref.whatWorked, whatDidnt: ref.whatDidnt,
+      wishIKnew: (ref.wishIKnew as string) ?? null, doDifferently: (ref.doDifferently as string) ?? null,
+      toolsNeeded: ref.toolsNeeded,
+    });
+    return ref;
+  } catch {
+    return null;
+  }
+}
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
   const { request, env } = context;
@@ -275,6 +375,25 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     const wisdom = await retrieveWisdom(env, active, 4);
     const injected = renderWisdom(wisdom);
     return new Response(renderWisdomPage(token, categories, active, lessons, injected), {
+      status: 200,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // --- Public feature flags (JSON) ----------------------------------------
+  if (sub === "flags") {
+    return json(await getFlags(env));
+  }
+
+  // --- Replay viewer: watch the whole agentic process step by step --------
+  if (sub === "replay") {
+    const id = url.searchParams.get("id") || "";
+    const token = url.searchParams.get("token") || "";
+    if (!id) return new Response("Missing ?id", { status: 400 });
+    const gen = await getGeneration(env, id);
+    if (!gen) return new Response("Unknown generation", { status: 404 });
+    const events = await getEvents(env, id);
+    return new Response(renderReplayPage(token, gen, events), {
       status: 200,
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
@@ -329,6 +448,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
 
   const activeModel = await resolveDrawModel(env);
   const activeInfo = modelInfo(activeModel);
+  const flags = await getFlags(env);
 
   const esc = (s: unknown) =>
     String(s ?? "")
@@ -356,7 +476,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           ${g.description ? `<div class="desc">${esc(g.description)}</div>` : ""}
           ${g.cues_and_strategies ? `<div class="lesson"><b>lesson:</b> ${esc(g.cues_and_strategies)}</div>` : ""}
           ${g.do_differently ? `<div class="lesson"><b>next time:</b> ${esc(g.do_differently)}</div>` : ""}
-          <div class="when">${esc(g.created_at)} · ${esc(String(g.cookie_uuid).slice(0, 8))}</div>
+          <div class="when">${esc(g.created_at)} · ${esc(String(g.cookie_uuid).slice(0, 8))}${g.aesthetic_score ? ` · ★${esc(g.aesthetic_score)}/5` : ""} · <a href="/api/admin/replay?token=${t}&id=${esc(g.id)}">🎬 replay</a></div>
         </div>
       </div>`;
     })
@@ -388,6 +508,26 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       <span class="hint">Free-tier drawings only. Classification &amp; reflection always use the cheap recommended model. ~$/draw assumes ~1.5K in / 2.5K out tokens. Bring-your-own-key users are unaffected.</span>
     </div>
   </form>`;
+
+  const flagsPanel = `<div class="models" id="flagsPanel">
+    <div class="mhead"><span>🎛️ What the public gets</span>
+      <span class="hint">Your own batch runs ignore these — this only limits anonymous visitors. Vision features need the active model to be vision-capable.</span></div>
+    <div style="display:flex;gap:16px;flex-wrap:wrap;padding:6px 0">
+      <label><input type="checkbox" id="f-references" ${flags.references ? "checked" : ""}> look at references 👁</label>
+      <label><input type="checkbox" id="f-critique" ${flags.critique ? "checked" : ""}> vision critique 👁</label>
+      <label><input type="checkbox" id="f-iterative" ${flags.iterative ? "checked" : ""}> allow "another turn"</label>
+      <label>max turns <input type="number" id="f-maxTurns" value="${flags.maxTurns}" min="1" max="6" style="width:60px"></label>
+      <button type="button" id="f-save">Save public features</button>
+      <span id="f-saved" style="color:#080;display:none">saved ✓</span>
+    </div>
+  </div>
+  <script>
+    document.getElementById("f-save").onclick=async()=>{
+      const body={references:document.getElementById("f-references").checked,critique:document.getElementById("f-critique").checked,iterative:document.getElementById("f-iterative").checked,maxTurns:parseInt(document.getElementById("f-maxTurns").value)||1};
+      await fetch("/api/admin/flags?token=${t}",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
+      const s=document.getElementById("f-saved"); s.style.display="inline"; setTimeout(()=>s.style.display="none",1500);
+    };
+  </script>`;
 
   const html = `<!doctype html><html><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -441,6 +581,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   <span class="stat">showing latest ${gens.results?.length ?? 0}</span>
 </header>
 ${modelPanel}
+${flagsPanel}
 <div class="grid">${cards || "<p style='padding:12px'>No drawings yet.</p>"}</div>
 </body></html>`;
 
@@ -472,98 +613,12 @@ const PAGE_CSS = `
   input,select{font-family:inherit;font-size:12px;padding:3px 5px;border:2px inset #fff;background:#fff}
 `;
 
-// --- Batch console ---------------------------------------------------------
-function renderBatchPage(token: string): string {
-  const t = encodeURIComponent(token);
-  const opts = MODEL_CATALOG.map((m) => {
-    const cost = (1500 / 1e6) * m.inPrice + (2500 / 1e6) * m.outPrice;
-    const sel = m.id === "@cf/openai/gpt-oss-120b" ? "selected" : "";
-    const tag = m.extreme === "best" ? " ★BEST" : m.extreme === "worst" ? " ✖WORST" : "";
-    return `<option value="${he(m.id)}" data-cost="${cost.toFixed(5)}" ${sel}>${he(m.label)}${tag} — ~$${cost.toFixed(4)}/draw (${m.tier})</option>`;
-  }).join("");
-
-  return `<!doctype html><html><head><meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Batch Run · MSPaint Admin</title>
-<style>${PAGE_CSS}
-  .controls{display:flex;gap:10px;flex-wrap:wrap;align-items:end}
-  .controls label{display:flex;flex-direction:column;font-size:11px;font-weight:bold;gap:3px}
-  .stats{display:flex;gap:8px;flex-wrap:wrap;margin:10px 0}
-  .stat{background:#fff;border:2px inset #fff;padding:4px 10px;font-variant-numeric:tabular-nums}
-  .stat b{display:block;font-size:18px;color:#000080}
-  .bar{height:18px;background:#fff;border:2px inset #fff;margin:6px 0;position:relative}
-  .bar > div{height:100%;background:#000080;width:0%}
-  .layout{display:grid;grid-template-columns:1fr 320px;gap:12px}
-  @media(max-width:800px){.layout{grid-template-columns:1fr}}
-  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(96px,1fr));gap:6px;max-height:60vh;overflow:auto;background:#808080;padding:6px;border:2px inset #fff}
-  .cell{background:#fff;border:1px solid #404040;position:relative}
-  .cell canvas{width:100%;display:block;image-rendering:pixelated;aspect-ratio:4/3}
-  .cell.fail{outline:2px solid #c00}
-  .cell .n{position:absolute;top:0;left:0;background:#000080;color:#fff;font-size:9px;padding:0 3px}
-  .side .panel{background:#fff;border:2px inset #fff;padding:8px;margin-bottom:10px}
-  .side h3{margin:0 0 6px;font-size:12px;background:#000080;color:#fff;padding:3px 6px}
-  .wisbox{background:#ffffcc;border:1px solid #808080;padding:6px;font-size:11px;white-space:pre-wrap;max-height:220px;overflow:auto}
-  .growth{font-size:11px;color:#333}
-</style></head><body>
-<header>
-  <span>▶ Batch Run</span>
-  <a href="/api/admin?token=${t}">← gallery</a>
-  <a href="/api/admin/wisdom?token=${t}">🧠 wisdom explorer</a>
-</header>
-
-<div class="win">
-  <h2>Soak test: run a model N times on one prompt &amp; watch wisdom accrue</h2>
-  <div class="controls">
-    <label>Model
-      <select id="model" style="min-width:340px">${opts}</select>
-    </label>
-    <label>Prompt
-      <input id="prompt" value="a cat sitting on a windowsill at sunset" style="min-width:280px">
-    </label>
-    <label>Count
-      <input id="count" type="number" value="100" min="1" max="500" style="width:80px">
-    </label>
-    <button id="go">Run</button>
-    <button id="stop" disabled>Stop</button>
-  </div>
-  <div class="stats">
-    <div class="stat"><b id="s-done">0</b>done / <span id="s-total">0</span></div>
-    <div class="stat"><b id="s-ok">0</b>parsed ok</div>
-    <div class="stat"><b id="s-fail">0</b>parse fails</div>
-    <div class="stat"><b id="s-cmd">0</b>avg commands</div>
-    <div class="stat"><b id="s-lat">0</b>avg latency (ms)</div>
-    <div class="stat"><b id="s-cost">$0.00</b>est spend</div>
-    <div class="stat"><b id="s-les">0</b>lessons accrued</div>
-  </div>
-  <div class="bar"><div id="bar"></div></div>
-</div>
-
-<div class="win layout">
-  <div>
-    <h2>Drawings (rendered live)</h2>
-    <div class="grid" id="grid"></div>
-  </div>
-  <div class="side">
-    <div class="panel">
-      <h3>What the agent saw this run</h3>
-      <div class="growth">Injected lessons grow as the batch runs — this is the accrual flywheel.</div>
-      <div class="wisbox" id="wisdom">(none yet — early runs have no accrued wisdom)</div>
-    </div>
-    <div class="panel">
-      <h3>Latest lesson elicited</h3>
-      <div class="wisbox" id="lesson">(waiting…)</div>
-    </div>
-  </div>
-</div>
-
-<script>
-const TOKEN = ${JSON.stringify(token)};
-let stop = false;
-
-// --- compact command renderer (mirrors the app's canvas) ------------------
-function render(ctx, cmds){
+// Shared client-side command renderer (mirrors the app canvas). render(ctx,
+// cmds, clear) — pass clear=false to draw continuation passes on top.
+const RENDERER_JS = `
+function render(ctx, cmds, clear){
   let fg = "#000000", bg = "#FFFFFF";
-  ctx.fillStyle = "#FFFFFF"; ctx.fillRect(0,0,640,480);
+  if(clear !== false){ ctx.fillStyle = "#FFFFFF"; ctx.fillRect(0,0,640,480); }
   for(const c of (cmds||[])){
     try{
       switch(c.type){
@@ -606,72 +661,261 @@ function sprayAt(ctx,fg,x,y){ ctx.fillStyle=fg; for(let i=0;i<14;i++){ const a=M
 function flood(ctx,x,y,hex){ if(x<0||y<0||x>=640||y>=480) return;
   const img=ctx.getImageData(0,0,640,480), d=img.data, idx=(y*640+x)*4;
   const tr=d[idx],tg=d[idx+1],tb=d[idx+2];
-  const m=hex.replace("#",""); const fr=parseInt(m.slice(0,2),16),fgc=parseInt(m.slice(2,4),16),fb=parseInt(m.slice(4,6),16);
+  const mm=(hex||"#000000").replace("#",""); const fr=parseInt(mm.slice(0,2),16),fgc=parseInt(mm.slice(2,4),16),fb=parseInt(mm.slice(4,6),16);
   if(tr===fr&&tg===fgc&&tb===fb) return;
   const st=[[x,y]]; let guard=0;
-  while(st.length && guard++<300000){ const [cx,cy]=st.pop(); if(cx<0||cy<0||cx>=640||cy>=480) continue;
+  while(st.length && guard++<300000){ const p=st.pop(), cx=p[0], cy=p[1]; if(cx<0||cy<0||cx>=640||cy>=480) continue;
     const i=(cy*640+cx)*4; if(d[i]!==tr||d[i+1]!==tg||d[i+2]!==tb) continue;
     d[i]=fr; d[i+1]=fgc; d[i+2]=fb; d[i+3]=255;
     st.push([cx+1,cy],[cx-1,cy],[cx,cy+1],[cx,cy-1]); }
   ctx.putImageData(img,0,0); }
+`;
 
-// --- batch loop -----------------------------------------------------------
+// --- Batch console / admin playground --------------------------------------
+function renderBatchPage(token: string): string {
+  const t = encodeURIComponent(token);
+  const opts = MODEL_CATALOG.map((m) => {
+    const cost = (1500 / 1e6) * m.inPrice + (2500 / 1e6) * m.outPrice;
+    const sel = m.id === "@cf/openai/gpt-oss-120b" ? "selected" : "";
+    const tag = m.extreme === "best" ? " ★BEST" : m.extreme === "worst" ? " ✖WORST" : "";
+    return `<option value="${he(m.id)}" data-cost="${cost.toFixed(5)}" data-vision="${m.vision ? 1 : 0}" ${sel}>${he(m.label)}${tag} — ~$${cost.toFixed(4)}/draw${m.vision ? " 👁" : ""} (${m.tier})</option>`;
+  }).join("");
+
+  return `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Batch Run · MSPaint Admin</title>
+<style>${PAGE_CSS}
+  .controls{display:flex;gap:10px;flex-wrap:wrap;align-items:end}
+  .controls label{display:flex;flex-direction:column;font-size:11px;font-weight:bold;gap:3px}
+  .controls .chk{flex-direction:row;align-items:center;gap:5px}
+  .stats{display:flex;gap:8px;flex-wrap:wrap;margin:10px 0}
+  .stat{background:#fff;border:2px inset #fff;padding:4px 10px;font-variant-numeric:tabular-nums}
+  .stat b{display:block;font-size:18px;color:#000080}
+  .bar{height:18px;background:#fff;border:2px inset #fff;margin:6px 0;position:relative}
+  .bar > div{height:100%;background:#000080;width:0%}
+  .layout{display:grid;grid-template-columns:1fr 320px;gap:12px}
+  @media(max-width:800px){.layout{grid-template-columns:1fr}}
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(96px,1fr));gap:6px;max-height:60vh;overflow:auto;background:#808080;padding:6px;border:2px inset #fff}
+  .cell{background:#fff;border:1px solid #404040;position:relative;cursor:pointer}
+  .cell canvas{width:100%;display:block;image-rendering:pixelated;aspect-ratio:4/3}
+  .cell.fail{outline:2px solid #c00}
+  .cell .n{position:absolute;top:0;left:0;background:#000080;color:#fff;font-size:9px;padding:0 3px}
+  .cell .sc{position:absolute;top:0;right:0;background:#080;color:#fff;font-size:9px;padding:0 3px}
+  .side .panel{background:#fff;border:2px inset #fff;padding:8px;margin-bottom:10px}
+  .side h3{margin:0 0 6px;font-size:12px;background:#000080;color:#fff;padding:3px 6px}
+  .wisbox{background:#ffffcc;border:1px solid #808080;padding:6px;font-size:11px;white-space:pre-wrap;max-height:200px;overflow:auto}
+  .growth{font-size:11px;color:#333}
+  .hint{font-size:10px;color:#404040;margin-top:6px}
+</style></head><body>
+<header>
+  <span>▶ Batch Run · your playground</span>
+  <a href="/api/admin?token=${t}">← gallery</a>
+  <a href="/api/admin/wisdom?token=${t}">🧠 wisdom explorer</a>
+</header>
+
+<div class="win">
+  <h2>Soak test: run any model N× with any options &amp; watch the skill accrue</h2>
+  <div class="controls">
+    <label>Model<select id="model" style="min-width:320px">${opts}</select></label>
+    <label>Prompt<input id="prompt" value="a cat sitting on a windowsill at sunset" style="min-width:240px"></label>
+    <label>Count<input id="count" type="number" value="100" min="1" max="500" style="width:74px"></label>
+    <label>Max turns<input id="turns" type="number" value="3" min="1" max="6" style="width:64px"></label>
+    <label class="chk"><input type="checkbox" id="refs"> look at references 👁</label>
+    <label class="chk"><input type="checkbox" id="crit" checked> vision critique 👁</label>
+    <button id="go">Run</button>
+    <button id="stop" disabled>Stop</button>
+  </div>
+  <div class="hint">References &amp; critique &amp; multi-turn need a 👁 vision model (Kimi, Llama 4 Scout). "Max turns" lets the agent ask to keep drawing so it doesn't quit early with a sparse picture. This is YOUR playground — any model, any options, unrestricted.</div>
+  <div class="stats">
+    <div class="stat"><b id="s-done">0</b>done / <span id="s-total">0</span></div>
+    <div class="stat"><b id="s-ok">0</b>parsed ok</div>
+    <div class="stat"><b id="s-fail">0</b>parse fails</div>
+    <div class="stat"><b id="s-cmd">0</b>avg commands</div>
+    <div class="stat"><b id="s-turn">0</b>avg turns</div>
+    <div class="stat"><b id="s-score">–</b>avg score /5</div>
+    <div class="stat"><b id="s-lat">0</b>avg latency (ms)</div>
+    <div class="stat"><b id="s-cost">$0.00</b>est spend</div>
+    <div class="stat"><b id="s-les">0</b>lessons accrued</div>
+  </div>
+  <div class="bar"><div id="bar"></div></div>
+</div>
+
+<div class="win layout">
+  <div>
+    <h2>Drawings (rendered live — click one to replay)</h2>
+    <div class="grid" id="grid"></div>
+  </div>
+  <div class="side">
+    <div class="panel"><h3>What the agent saw this run</h3>
+      <div class="growth">Injected lessons grow as the run proceeds — the accrual flywheel.</div>
+      <div class="wisbox" id="wisdom">(none yet)</div></div>
+    <div class="panel"><h3>Latest critique / lesson</h3><div class="wisbox" id="lesson">(waiting…)</div></div>
+  </div>
+</div>
+
+<script>
+const TOKEN = ${JSON.stringify(token)};
+let stop = false;
+${RENDERER_JS}
 const $ = id => document.getElementById(id);
-let done=0, ok=0, fail=0, cmdSum=0, latSum=0, spend=0, lessons=0;
+const post = (path, body) => fetch(path+"?token="+encodeURIComponent(TOKEN),{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)}).then(r=>r.json());
+let done=0, ok=0, fail=0, cmdSum=0, latSum=0, spend=0, lessons=0, turnSum=0, scoreSum=0, scoreN=0;
 
 async function run(){
-  stop=false; done=ok=fail=cmdSum=latSum=spend=lessons=0;
-  const model=$("model").value, prompt=$("prompt").value.trim();
+  stop=false; done=ok=fail=cmdSum=latSum=spend=lessons=turnSum=scoreSum=scoreN=0;
+  const opt=$("model").selectedOptions[0];
+  const model=$("model").value, vision=opt.dataset.vision==="1";
+  const prompt=$("prompt").value.trim();
   const total=Math.max(1,Math.min(500,parseInt($("count").value)||1));
-  const cost=parseFloat($("model").selectedOptions[0].dataset.cost||"0");
+  const maxTurns=Math.max(1,Math.min(6,parseInt($("turns").value)||1));
+  const refs=$("refs").checked && vision, crit=$("crit").checked && vision;
+  const cost=parseFloat(opt.dataset.cost||"0");
   const batchId=crypto.randomUUID();
   $("grid").innerHTML=""; $("s-total").textContent=total;
   $("go").disabled=true; $("stop").disabled=false;
 
   for(let i=0;i<total && !stop;i++){
     let res;
-    try{
-      const r=await fetch("/api/admin/run?token="+encodeURIComponent(TOKEN),{
-        method:"POST",headers:{"Content-Type":"application/json"},
-        body:JSON.stringify({model,prompt,batchId,index:i,total})});
-      res=await r.json();
-    }catch(e){ res={ok:false,commandCount:0,latencyMs:0,wisdomShown:"",rawError:String(e)}; }
-
+    try{ res=await post("/api/admin/run",{model,prompt,batchId,index:i,total,references:refs,reflect:!crit}); }
+    catch(e){ res={ok:false,commandCount:0,latencyMs:0,wisdomShown:"",rawError:String(e)}; }
     done++; latSum+=res.latencyMs||0; spend+=cost;
     if(res.ok){ ok++; cmdSum+=res.commandCount||0; } else { fail++; }
-    if(res.lesson) lessons++;
 
-    // render + upload
     const cv=document.createElement("canvas"); cv.width=640; cv.height=480;
-    const ctx=cv.getContext("2d"); render(ctx, res.commands);
+    const ctx=cv.getContext("2d",{willReadFrequently:true}); render(ctx, res.commands, true);
+
+    // look-as-you-go: agent-requested extra turns (vision only)
+    let turns=1, totalCmd=res.commandCount||0;
+    while(vision && res.ok && res.needsAnotherTurn && turns<maxTurns && !stop){
+      const cont=await post("/api/admin/continue",{generationId:res.generationId,model,prompt,category:res.category,pass:turns,currentImage:cv.toDataURL("image/png")});
+      spend+=cost; render(ctx, cont.commands, false); totalCmd+=cont.commandCount||cont.commands?.length||0;
+      res.needsAnotherTurn=cont.needsAnotherTurn; turns++;
+    }
+    turnSum+=turns;
+
+    // vision critique of the final render
+    let score=null;
+    if(crit && res.ok && res.generationId){
+      const cr=await post("/api/admin/critique",{generationId:res.generationId,prompt,image:cv.toDataURL("image/png"),category:res.category,commandCount:totalCmd,passCount:turns,model});
+      spend+=cost*0.3;
+      if(cr.critique){ lessons++; score=Number(cr.critique.aestheticScore); if(isFinite(score)){scoreSum+=score;scoreN++;}
+        $("lesson").textContent="score "+(isFinite(score)?score:"?")+"/5\\ncues: "+(cr.critique.cuesAndStrategies||"—")+"\\nnext: "+(cr.critique.doDifferently||"—"); }
+    } else if(res.lesson){ lessons++; $("lesson").textContent="cues: "+(res.lesson.cuesAndStrategies||"—")+"\\nnext: "+(res.lesson.doDifferently||"—"); }
+
+    // cell (click to replay)
     const cell=document.createElement("div"); cell.className="cell"+(res.ok?"":" fail");
     const thumb=document.createElement("canvas"); thumb.width=160; thumb.height=120;
-    thumb.getContext("2d").drawImage(cv,0,0,160,120);
-    cell.appendChild(thumb);
-    const n=document.createElement("div"); n.className="n"; n.textContent="#"+(i+1); cell.appendChild(n);
-    cell.title=(res.description||res.rawError||"")+" · "+(res.commandCount||0)+" cmds · "+(res.latencyMs||0)+"ms";
+    thumb.getContext("2d").drawImage(cv,0,0,160,120); cell.appendChild(thumb);
+    const n=document.createElement("div"); n.className="n"; n.textContent="#"+(i+1)+(turns>1?(" ×"+turns):""); cell.appendChild(n);
+    if(score!=null&&isFinite(score)){ const s=document.createElement("div"); s.className="sc"; s.textContent=score.toFixed(1); cell.appendChild(s); }
+    if(res.generationId) cell.onclick=()=>window.open("/api/admin/replay?id="+res.generationId+"&token="+encodeURIComponent(TOKEN));
+    cell.title=(res.description||res.rawError||"")+" · "+totalCmd+" cmds · "+turns+" turns";
     $("grid").appendChild(cell);
+
     if(res.ok && res.generationId){
-      cv.toBlob(b=>{ const fr=new FileReader(); fr.onload=()=>{
-        fetch("/api/mspaint/snapshot",{method:"POST",headers:{"Content-Type":"application/json"},
-          body:JSON.stringify({generationId:res.generationId,image:fr.result})}).catch(()=>{}); };
-        fr.readAsDataURL(b); },"image/png");
+      cv.toBlob(b=>{ const fr=new FileReader(); fr.onload=()=>post("/api/mspaint/snapshot",{generationId:res.generationId,image:fr.result}).catch(()=>{}); fr.readAsDataURL(b); },"image/png");
     }
 
-    // metrics
     $("s-done").textContent=done; $("s-ok").textContent=ok; $("s-fail").textContent=fail;
     $("s-cmd").textContent=ok?Math.round(cmdSum/ok):0;
+    $("s-turn").textContent=(turnSum/done).toFixed(1);
+    $("s-score").textContent=scoreN?(scoreSum/scoreN).toFixed(2):"–";
     $("s-lat").textContent=Math.round(latSum/done);
     $("s-cost").textContent="$"+spend.toFixed(3);
     $("s-les").textContent=lessons;
     $("bar").style.width=(done/total*100)+"%";
     $("wisdom").textContent=(res.wisdomShown&&res.wisdomShown.trim())?res.wisdomShown.trim():"(no accrued wisdom yet — keep going)";
-    if(res.lesson) $("lesson").textContent="cues & strategies: "+(res.lesson.cuesAndStrategies||"—")+"\\n\\ndo differently: "+(res.lesson.doDifferently||"—");
   }
   $("go").disabled=false; $("stop").disabled=true;
 }
-$("go").onclick=run;
-$("stop").onclick=()=>{ stop=true; };
+$("go").onclick=run; $("stop").onclick=()=>{ stop=true; };
+</script>
+</body></html>`;
+}
+
+// --- Replay viewer ---------------------------------------------------------
+function renderReplayPage(token: string, gen: Record<string, unknown>, events: Record<string, unknown>[]): string {
+  const t = encodeURIComponent(token);
+  const evJson = JSON.stringify(
+    events.map((e) => ({ seq: e.seq, phase: e.phase, type: e.type, ts: e.ts, data: e.data ? JSON.parse(String(e.data)) : null }))
+  );
+  const refKeys = gen.reference_keys ? (() => { try { return JSON.parse(String(gen.reference_keys)); } catch { return []; } })() : [];
+  const refImgs = (refKeys as string[])
+    .map((k) => `<img src="/api/admin/image?token=${t}&key=${encodeURIComponent(k)}">`)
+    .join("");
+
+  return `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Replay · MSPaint Admin</title>
+<style>${PAGE_CSS}
+  .layout{display:grid;grid-template-columns:660px 1fr;gap:12px}
+  @media(max-width:1000px){.layout{grid-template-columns:1fr}}
+  canvas#stage{background:#fff;border:2px inset #fff;width:640px;max-width:100%;image-rendering:pixelated;aspect-ratio:4/3}
+  .timeline{background:#fff;border:2px inset #fff;max-height:70vh;overflow:auto}
+  .ev{padding:6px 8px;border-bottom:1px solid #e0e0e0;font-size:12px;cursor:pointer}
+  .ev:hover{background:#ffffcc}
+  .ev.on{background:#000080;color:#fff}
+  .ev .ph{display:inline-block;min-width:74px;font-weight:bold}
+  .ev pre{margin:4px 0 0;white-space:pre-wrap;font-size:11px;color:#333}
+  .ev.on pre{color:#cde}
+  .refs img{height:80px;border:2px inset #fff;margin-right:6px}
+  .ctrls{margin:8px 0;display:flex;gap:8px;align-items:center}
+  .meta{font-size:12px;margin-bottom:8px}
+</style></head><body>
+<header>
+  <span>🎬 Replay</span>
+  <a href="/api/admin?token=${t}">← gallery</a>
+  <a href="/api/admin/batch?token=${t}">▶ batch</a>
+</header>
+<div class="win">
+  <div class="meta"><b>${he(gen.prompt)}</b> · ${he(gen.model)} · ${he(gen.category)} · ${he(gen.command_count)} cmds${gen.aesthetic_score ? " · score " + he(gen.aesthetic_score) + "/5" : ""}</div>
+  ${refImgs ? `<div class="refs"><b>Looked at:</b><br>${refImgs}</div>` : ""}
+  <div class="layout">
+    <div>
+      <canvas id="stage" width="640" height="480"></canvas>
+      <div class="ctrls"><button id="play">▶ Play</button><button id="reset">⏮ Reset</button><span id="status"></span></div>
+    </div>
+    <div class="timeline" id="tl"></div>
+  </div>
+</div>
+<script>
+const EVENTS = ${evJson};
+${RENDERER_JS}
+const stage=document.getElementById("stage"), sctx=stage.getContext("2d",{willReadFrequently:true});
+sctx.fillStyle="#fff"; sctx.fillRect(0,0,640,480);
+const tl=document.getElementById("tl");
+const phaseLabel={assess:"ASSESS",search:"SEARCH",look:"LOOK",plan:"PLAN",draw:"DRAW",critique:"CRITIQUE",turn:"TURN"};
+EVENTS.forEach((e,i)=>{
+  const d=document.createElement("div"); d.className="ev"; d.id="ev"+i;
+  let summary="";
+  if(e.phase==="assess") summary="category: "+(e.data&&e.data.category||"?");
+  else if(e.phase==="search") summary='searched: "'+(e.data&&e.data.query||"")+'"';
+  else if(e.phase==="look") summary=e.data&&e.data.url?("looked at reference"):("looked at its own canvas (turn "+(e.data&&e.data.pass||"?")+")");
+  else if(e.phase==="plan") summary=(e.data&&e.data.plan?(Array.isArray(e.data.plan)?e.data.plan.join(" → "):e.data.plan):"(planned)");
+  else if(e.phase==="draw") summary="drew "+(e.data&&e.data.commandCount||0)+" commands (turn "+((e.data&&e.data.pass||0)+1)+")"+((e.data&&e.data.needsAnotherTurn)?" — wants another turn":"");
+  else if(e.phase==="critique") summary="score "+(e.data&&e.data.aestheticScore||"?")+"/5 — "+(e.data&&e.data.doDifferently||"");
+  d.innerHTML='<span class="ph">'+(phaseLabel[e.phase]||e.phase)+'</span>'+summary;
+  d.onclick=()=>seek(i);
+  tl.appendChild(d);
+});
+function applyTo(idx){ // render canvas state through event idx
+  sctx.fillStyle="#fff"; sctx.fillRect(0,0,640,480);
+  let first=true;
+  for(let i=0;i<=idx;i++){ const e=EVENTS[i];
+    if(e.phase==="draw" && e.data && e.data.commands){ render(sctx, e.data.commands, first); first=false; } }
+  EVENTS.forEach((e,i)=>document.getElementById("ev"+i).classList.toggle("on",i===idx));
+  const el=document.getElementById("ev"+idx); if(el) el.scrollIntoView({block:"nearest"});
+}
+function seek(i){ applyTo(i); }
+let playing=false;
+document.getElementById("play").onclick=async()=>{
+  if(playing) return; playing=true;
+  for(let i=0;i<EVENTS.length;i++){ applyTo(i); document.getElementById("status").textContent="step "+(i+1)+"/"+EVENTS.length;
+    await new Promise(r=>setTimeout(r,650)); if(!playing) break; }
+  playing=false;
+};
+document.getElementById("reset").onclick=()=>{ playing=false; sctx.fillStyle="#fff"; sctx.fillRect(0,0,640,480); EVENTS.forEach((e,i)=>document.getElementById("ev"+i).classList.remove("on")); document.getElementById("status").textContent=""; };
+if(EVENTS.length) applyTo(EVENTS.length-1);
 </script>
 </body></html>`;
 }

--- a/website-next/functions/api/admin/[[path]].ts
+++ b/website-next/functions/api/admin/[[path]].ts
@@ -30,7 +30,7 @@ import {
   getGeneration,
   updateGenerationFinal,
 } from "../../_lib/db";
-import { resolveDrawModel, runText, runVision, classifyPrompt, UTILITY_MODEL } from "../../_lib/workers-ai";
+import { resolveDrawModel, runText, runTextRich, runVision, runVisionRich, classifyPrompt, UTILITY_MODEL } from "../../_lib/workers-ai";
 import {
   buildDrawSystemPrompt,
   buildContinuePrompt,
@@ -42,7 +42,7 @@ import {
   buildCritiqueUserContent,
   extractJson,
 } from "../../_lib/cta";
-import { MODEL_CATALOG, isAllowedModel, modelInfo, hasVision, VISION_CRITIC_MODEL } from "../../_lib/models";
+import { MODEL_CATALOG, isAllowedModel, modelInfo, hasVision, drawBudget, VISION_CRITIC_MODEL } from "../../_lib/models";
 import { searchReferences } from "../../_lib/references";
 import { storePng, storeDataUrl } from "../../_lib/r2";
 
@@ -168,13 +168,16 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
     // 4. Draw (vision if we have references, else text).
     let raw = "";
+    let drawReasoning: string | null = null;
     let parseOk = true;
     let needsAnotherTurn = false;
     let draw: { thinking: string | null; plan: unknown; description: string; commands: unknown[] } | null = null;
     try {
-      raw = refImages.length
-        ? await runVision(env, drawSystem, prompt, refImages, 4096, model)
-        : await runText(env, drawSystem, prompt, 4096, model);
+      const drawRes = refImages.length
+        ? await runVisionRich(env, drawSystem, prompt, refImages, drawBudget(model), model)
+        : await runTextRich(env, drawSystem, prompt, drawBudget(model), model);
+      raw = drawRes.text;
+      drawReasoning = drawRes.reasoning;
       const p = extractJson<{ thinking?: string; plan?: unknown; description?: string; commands?: unknown[]; needsAnotherTurn?: boolean }>(raw);
       if (p && Array.isArray(p.commands)) {
         draw = { thinking: p.thinking ?? null, plan: p.plan ?? null, description: p.description || "Drawing", commands: p.commands };
@@ -203,7 +206,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     // 5. Text reflection (unless caller will run a vision critique instead).
     let lesson: Record<string, unknown> | null = null;
     if (parseOk && draw && b.reflect !== false) {
-      lesson = await reflectAndStore(env, generationId, prompt, cls.category, cls.subcategories, draw.description, draw.commands.length);
+      lesson = await reflectAndStore(env, generationId, prompt, cls.category, cls.subcategories, draw.description, draw.commands.length, drawReasoning, draw.thinking);
     }
 
     if (b.batchId) await incrementBatch(env, b.batchId, parseOk).catch(() => {});
@@ -236,7 +239,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     let draw: { thinking: string | null; description: string; commands: unknown[] } | null = null;
     let raw = "";
     try {
-      raw = await runVision(env, buildContinuePrompt(wisdom), buildContinueUserContent(b.prompt, pass), [b.currentImage], 4096, model);
+      raw = await runVision(env, buildContinuePrompt(wisdom), buildContinueUserContent(b.prompt, pass), [b.currentImage], drawBudget(model), model);
       const p = extractJson<{ thinking?: string; description?: string; commands?: unknown[]; needsAnotherTurn?: boolean }>(raw);
       if (p && Array.isArray(p.commands)) {
         draw = { thinking: p.thinking ?? null, description: p.description || "continued", commands: p.commands };
@@ -301,13 +304,15 @@ async function reflectAndStore(
   category: string,
   subcategories: string[],
   description: string,
-  commandCount: number
+  commandCount: number,
+  reasoning?: string | null,
+  thinking?: string | null
 ): Promise<Record<string, unknown> | null> {
   try {
     const text = await runText(
       env,
       REFLECTION_SYSTEM_PROMPT,
-      buildReflectionUserContent(prompt, category, description, commandCount),
+      buildReflectionUserContent(prompt, category, description, commandCount, reasoning, thinking),
       700,
       UTILITY_MODEL
     );

--- a/website-next/functions/api/admin/[[path]].ts
+++ b/website-next/functions/api/admin/[[path]].ts
@@ -12,8 +12,25 @@
  */
 
 import type { Env } from "../../_lib/env";
-import { setConfig, CONFIG_MODEL_KEY } from "../../_lib/db";
-import { resolveDrawModel } from "../../_lib/workers-ai";
+import {
+  setConfig,
+  CONFIG_MODEL_KEY,
+  recordGeneration,
+  recordLesson,
+  retrieveWisdom,
+  createBatch,
+  incrementBatch,
+  listLessonCategories,
+  getLessons,
+} from "../../_lib/db";
+import { resolveDrawModel, runText, classifyPrompt, UTILITY_MODEL } from "../../_lib/workers-ai";
+import {
+  buildDrawSystemPrompt,
+  renderWisdom,
+  REFLECTION_SYSTEM_PROMPT,
+  buildReflectionUserContent,
+  extractJson,
+} from "../../_lib/cta";
 import { MODEL_CATALOG, isAllowedModel, modelInfo } from "../../_lib/models";
 
 function timingSafeEqual(a: string, b: string): boolean {
@@ -40,35 +57,176 @@ const json = (data: unknown, status = 200) =>
     headers: { "Content-Type": "application/json" },
   });
 
-// --- Set the active free-tier drawing model -------------------------------
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   const { request, env } = context;
   if (!authorized(request, env)) return deny();
 
   const url = new URL(request.url);
   const parts = (context.params.path as string[] | undefined) || [];
-  if ((parts[0] || "") !== "model") return new Response("Not found", { status: 404 });
+  const sub = parts[0] || "";
 
-  const ct = request.headers.get("Content-Type") || "";
-  let model = "";
-  if (ct.includes("application/json")) {
-    const b = (await request.json()) as { model?: string };
-    model = b.model || "";
-  } else {
-    const form = await request.formData();
-    model = String(form.get("model") || "");
+  // --- Set the active free-tier drawing model -----------------------------
+  if (sub === "model") {
+    const ct = request.headers.get("Content-Type") || "";
+    let model = "";
+    if (ct.includes("application/json")) {
+      const b = (await request.json()) as { model?: string };
+      model = b.model || "";
+    } else {
+      const form = await request.formData();
+      model = String(form.get("model") || "");
+    }
+    if (!isAllowedModel(model)) return json({ error: "Model not in catalog" }, 400);
+    await setConfig(env, CONFIG_MODEL_KEY, model);
+    if (ct.includes("application/json")) return json({ ok: true, model });
+    const token = url.searchParams.get("token") || "";
+    return new Response(null, {
+      status: 303,
+      headers: { Location: `/api/admin?token=${encodeURIComponent(token)}` },
+    });
   }
 
-  if (!isAllowedModel(model)) return json({ error: "Model not in catalog" }, 400);
-  await setConfig(env, CONFIG_MODEL_KEY, model);
+  // --- Run ONE drawing iteration (the soak-test unit) ---------------------
+  if (sub === "run") {
+    if (!env.AI || !env.MSPAINT_DB) return json({ error: "AI/DB not bound" }, 500);
+    const started = Date.now();
+    const b = (await request.json()) as {
+      model?: string;
+      prompt?: string;
+      batchId?: string;
+      index?: number;
+      total?: number;
+    };
+    const model = b.model && isAllowedModel(b.model) ? b.model : "";
+    const prompt = (b.prompt || "").trim();
+    if (!model) return json({ error: "Unknown model" }, 400);
+    if (!prompt) return json({ error: "Prompt required" }, 400);
 
-  // JSON callers get JSON; HTML form submits redirect back to the gallery.
-  if (ct.includes("application/json")) return json({ ok: true, model });
-  const token = url.searchParams.get("token") || "";
-  return new Response(null, {
-    status: 303,
-    headers: { Location: `/api/admin?token=${encodeURIComponent(token)}` },
-  });
+    // First iteration opens the batch record.
+    if (b.batchId && (b.index || 0) === 0) {
+      await createBatch(env, { id: b.batchId, model, prompt, target: b.total || 1 }).catch(() => {});
+    }
+
+    // 1. Situation assessment (cheap).
+    const cls = await classifyPrompt(env, prompt).catch(() => ({
+      category: "general",
+      subcategories: [] as string[],
+      tools: [] as string[],
+    }));
+
+    // 2. Recall accrued wisdom — capture exactly what the agent will see.
+    const wisdom = await retrieveWisdom(env, cls.category, 4);
+    const wisdomShown = renderWisdom(wisdom);
+    const drawSystem = buildDrawSystemPrompt(wisdom);
+
+    // 3. Draw with the chosen (premium) model.
+    let raw = "";
+    let parseOk = true;
+    let draw: { thinking: string | null; plan: unknown; description: string; commands: unknown[] } | null = null;
+    try {
+      raw = await runText(env, drawSystem, prompt, 4096, model);
+      const p = extractJson<{ thinking?: string; plan?: unknown; description?: string; commands?: unknown[] }>(raw);
+      if (p && Array.isArray(p.commands)) {
+        draw = {
+          thinking: p.thinking ?? null,
+          plan: p.plan ?? null,
+          description: p.description || "Drawing",
+          commands: p.commands,
+        };
+      } else {
+        parseOk = false;
+      }
+    } catch (e) {
+      parseOk = false;
+      raw = e instanceof Error ? e.message : "error";
+    }
+
+    const generationId = crypto.randomUUID();
+    const latencyMs = Date.now() - started;
+    const adminIdentity = {
+      cookieUuid: "admin-batch",
+      ipUaHash: "admin",
+      isNewCookie: false,
+      country: null,
+      userAgent: "admin-batch",
+    };
+
+    await recordGeneration(env, {
+      id: generationId,
+      userId: "admin-batch",
+      identity: adminIdentity,
+      provider: "batch",
+      model,
+      prompt,
+      category: cls.category,
+      subcategories: cls.subcategories,
+      recommendedTools: cls.tools,
+      thinking: draw?.thinking,
+      plan: draw?.plan,
+      description: draw?.description,
+      commands: draw?.commands,
+      commandCount: draw?.commands.length,
+      latencyMs,
+      status: parseOk ? "ok" : "error",
+      error: parseOk ? null : "parse_failed",
+      batchId: b.batchId ?? null,
+    }).catch(() => {});
+
+    // 4. Reflection (cheap utility model) — accrue a lesson, awaited so the
+    //    next iteration can immediately recall it.
+    let lesson: Record<string, unknown> | null = null;
+    if (parseOk && draw) {
+      try {
+        const text = await runText(
+          env,
+          REFLECTION_SYSTEM_PROMPT,
+          buildReflectionUserContent(prompt, cls.category, draw.description, draw.commands.length),
+          700,
+          UTILITY_MODEL
+        );
+        const ref = extractJson<Record<string, unknown>>(text);
+        if (ref) {
+          await recordLesson(env, {
+            id: crypto.randomUUID(),
+            generationId,
+            category: cls.category,
+            subcategories: cls.subcategories,
+            difficultElement: (ref.difficultElement as string) ?? null,
+            whyDifficult: (ref.whyDifficult as string) ?? null,
+            commonErrors: (ref.commonErrors as string) ?? null,
+            cuesAndStrategies: (ref.cuesAndStrategies as string) ?? null,
+            whatWorked: ref.whatWorked,
+            whatDidnt: ref.whatDidnt,
+            wishIKnew: (ref.wishIKnew as string) ?? null,
+            doDifferently: (ref.doDifferently as string) ?? null,
+            toolsNeeded: ref.toolsNeeded,
+          });
+          lesson = ref;
+        }
+      } catch {
+        /* reflection is best-effort */
+      }
+    }
+
+    if (b.batchId) await incrementBatch(env, b.batchId, parseOk).catch(() => {});
+
+    return json({
+      ok: parseOk,
+      generationId,
+      model,
+      category: cls.category,
+      latencyMs,
+      commandCount: draw?.commands.length ?? 0,
+      description: draw?.description ?? null,
+      commands: draw?.commands ?? [],
+      wisdomCount: wisdom.length,
+      wisdomShown, // exactly the "Lessons from artists past" text injected
+      lesson,
+      rawError: parseOk ? null : raw.slice(0, 300),
+    });
+  }
+
+  return new Response("Not found", { status: 404 });
 };
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
@@ -96,6 +254,30 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   if (sub === "models") {
     const active = await resolveDrawModel(env);
     return json({ active, catalog: MODEL_CATALOG });
+  }
+
+  // --- Batch console (premium model x N soak test) ------------------------
+  if (sub === "batch") {
+    const token = url.searchParams.get("token") || "";
+    return new Response(renderBatchPage(token), {
+      status: 200,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // --- Wisdom explorer ----------------------------------------------------
+  if (sub === "wisdom") {
+    const token = url.searchParams.get("token") || "";
+    const cat = url.searchParams.get("category");
+    const categories = await listLessonCategories(env);
+    const active = cat || categories[0]?.category || null;
+    const lessons = await getLessons(env, active, 60);
+    const wisdom = await retrieveWisdom(env, active, 4);
+    const injected = renderWisdom(wisdom);
+    return new Response(renderWisdomPage(token, categories, active, lessons, injected), {
+      status: 200,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
   }
 
   // --- Aggregate stats ----------------------------------------------------
@@ -214,6 +396,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   body{margin:0;background:#008080;color:#000;font:13px/1.4 "MS Sans Serif",Tahoma,system-ui,sans-serif}
   header{background:#000080;color:#fff;padding:8px 12px;font-weight:bold;display:flex;gap:16px;align-items:center;flex-wrap:wrap}
   header .stat{background:#c0c0c0;color:#000;padding:2px 8px;border:2px outset #fff;font-weight:normal}
+  header .nav{text-decoration:none;color:#000080;font-weight:bold;cursor:pointer}
+  header .nav:active{border-style:inset}
   .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:10px;padding:12px}
   .card{background:#c0c0c0;border:2px outset #fff;padding:6px}
   .thumb{background:#fff;border:2px inset #fff;aspect-ratio:4/3;display:flex;align-items:center;justify-content:center;overflow:hidden}
@@ -248,6 +432,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
 </style></head><body>
 <header>
   <span>🎨 MSPaint Admin</span>
+  <a class="stat nav" href="/api/admin/batch?token=${t}">▶ Batch run (100×)</a>
+  <a class="stat nav" href="/api/admin/wisdom?token=${t}">🧠 Wisdom explorer</a>
   <span class="stat">${stats?.users ?? 0} users</span>
   <span class="stat">${stats?.generations ?? 0} drawings</span>
   <span class="stat">${stats?.lessons ?? 0} lessons accrued</span>
@@ -260,3 +446,355 @@ ${modelPanel}
 
   return new Response(html, { status: 200, headers: { "Content-Type": "text/html; charset=utf-8" } });
 };
+
+// ===========================================================================
+// Shared HTML helpers + extra pages (batch console, wisdom explorer)
+// ===========================================================================
+
+function he(s: unknown): string {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+const PAGE_CSS = `
+  body{margin:0;background:#008080;color:#000;font:13px/1.5 "MS Sans Serif",Tahoma,system-ui,sans-serif}
+  header{background:#000080;color:#fff;padding:8px 12px;font-weight:bold;display:flex;gap:14px;align-items:center;flex-wrap:wrap}
+  header a{color:#9fd;text-decoration:none}
+  .win{margin:12px;background:#c0c0c0;border:2px outset #fff;padding:10px}
+  .win h2{margin:0 0 8px;font-size:14px}
+  code{font-family:"Courier New",monospace;font-size:11px;color:#000080}
+  button{background:#c0c0c0;border:2px outset #fff;padding:5px 16px;font-weight:bold;cursor:pointer;font-family:inherit}
+  button:active{border-style:inset}
+  button:disabled{color:#808080;cursor:default}
+  input,select{font-family:inherit;font-size:12px;padding:3px 5px;border:2px inset #fff;background:#fff}
+`;
+
+// --- Batch console ---------------------------------------------------------
+function renderBatchPage(token: string): string {
+  const t = encodeURIComponent(token);
+  const opts = MODEL_CATALOG.map((m) => {
+    const cost = (1500 / 1e6) * m.inPrice + (2500 / 1e6) * m.outPrice;
+    const sel = m.id === "@cf/openai/gpt-oss-120b" ? "selected" : "";
+    const tag = m.extreme === "best" ? " ★BEST" : m.extreme === "worst" ? " ✖WORST" : "";
+    return `<option value="${he(m.id)}" data-cost="${cost.toFixed(5)}" ${sel}>${he(m.label)}${tag} — ~$${cost.toFixed(4)}/draw (${m.tier})</option>`;
+  }).join("");
+
+  return `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Batch Run · MSPaint Admin</title>
+<style>${PAGE_CSS}
+  .controls{display:flex;gap:10px;flex-wrap:wrap;align-items:end}
+  .controls label{display:flex;flex-direction:column;font-size:11px;font-weight:bold;gap:3px}
+  .stats{display:flex;gap:8px;flex-wrap:wrap;margin:10px 0}
+  .stat{background:#fff;border:2px inset #fff;padding:4px 10px;font-variant-numeric:tabular-nums}
+  .stat b{display:block;font-size:18px;color:#000080}
+  .bar{height:18px;background:#fff;border:2px inset #fff;margin:6px 0;position:relative}
+  .bar > div{height:100%;background:#000080;width:0%}
+  .layout{display:grid;grid-template-columns:1fr 320px;gap:12px}
+  @media(max-width:800px){.layout{grid-template-columns:1fr}}
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(96px,1fr));gap:6px;max-height:60vh;overflow:auto;background:#808080;padding:6px;border:2px inset #fff}
+  .cell{background:#fff;border:1px solid #404040;position:relative}
+  .cell canvas{width:100%;display:block;image-rendering:pixelated;aspect-ratio:4/3}
+  .cell.fail{outline:2px solid #c00}
+  .cell .n{position:absolute;top:0;left:0;background:#000080;color:#fff;font-size:9px;padding:0 3px}
+  .side .panel{background:#fff;border:2px inset #fff;padding:8px;margin-bottom:10px}
+  .side h3{margin:0 0 6px;font-size:12px;background:#000080;color:#fff;padding:3px 6px}
+  .wisbox{background:#ffffcc;border:1px solid #808080;padding:6px;font-size:11px;white-space:pre-wrap;max-height:220px;overflow:auto}
+  .growth{font-size:11px;color:#333}
+</style></head><body>
+<header>
+  <span>▶ Batch Run</span>
+  <a href="/api/admin?token=${t}">← gallery</a>
+  <a href="/api/admin/wisdom?token=${t}">🧠 wisdom explorer</a>
+</header>
+
+<div class="win">
+  <h2>Soak test: run a model N times on one prompt &amp; watch wisdom accrue</h2>
+  <div class="controls">
+    <label>Model
+      <select id="model" style="min-width:340px">${opts}</select>
+    </label>
+    <label>Prompt
+      <input id="prompt" value="a cat sitting on a windowsill at sunset" style="min-width:280px">
+    </label>
+    <label>Count
+      <input id="count" type="number" value="100" min="1" max="500" style="width:80px">
+    </label>
+    <button id="go">Run</button>
+    <button id="stop" disabled>Stop</button>
+  </div>
+  <div class="stats">
+    <div class="stat"><b id="s-done">0</b>done / <span id="s-total">0</span></div>
+    <div class="stat"><b id="s-ok">0</b>parsed ok</div>
+    <div class="stat"><b id="s-fail">0</b>parse fails</div>
+    <div class="stat"><b id="s-cmd">0</b>avg commands</div>
+    <div class="stat"><b id="s-lat">0</b>avg latency (ms)</div>
+    <div class="stat"><b id="s-cost">$0.00</b>est spend</div>
+    <div class="stat"><b id="s-les">0</b>lessons accrued</div>
+  </div>
+  <div class="bar"><div id="bar"></div></div>
+</div>
+
+<div class="win layout">
+  <div>
+    <h2>Drawings (rendered live)</h2>
+    <div class="grid" id="grid"></div>
+  </div>
+  <div class="side">
+    <div class="panel">
+      <h3>What the agent saw this run</h3>
+      <div class="growth">Injected lessons grow as the batch runs — this is the accrual flywheel.</div>
+      <div class="wisbox" id="wisdom">(none yet — early runs have no accrued wisdom)</div>
+    </div>
+    <div class="panel">
+      <h3>Latest lesson elicited</h3>
+      <div class="wisbox" id="lesson">(waiting…)</div>
+    </div>
+  </div>
+</div>
+
+<script>
+const TOKEN = ${JSON.stringify(token)};
+let stop = false;
+
+// --- compact command renderer (mirrors the app's canvas) ------------------
+function render(ctx, cmds){
+  let fg = "#000000", bg = "#FFFFFF";
+  ctx.fillStyle = "#FFFFFF"; ctx.fillRect(0,0,640,480);
+  for(const c of (cmds||[])){
+    try{
+      switch(c.type){
+        case "setForegroundColor": fg = c.color || fg; break;
+        case "setBackgroundColor": bg = c.color || bg; break;
+        case "clearCanvas": ctx.fillStyle="#FFFFFF"; ctx.fillRect(0,0,640,480); break;
+        case "drawPixel": ctx.fillStyle=fg; ctx.fillRect(c.x,c.y,1,1); break;
+        case "drawLine": ctx.strokeStyle=fg; ctx.lineWidth=2; ctx.lineCap="round";
+          ctx.beginPath(); ctx.moveTo(c.x1,c.y1); ctx.lineTo(c.x2,c.y2); ctx.stroke(); break;
+        case "drawFreehand": if(c.points&&c.points.length){ ctx.strokeStyle=fg; ctx.lineWidth=2; ctx.lineJoin="round";
+          ctx.beginPath(); ctx.moveTo(c.points[0].x,c.points[0].y);
+          for(let i=1;i<c.points.length;i++) ctx.lineTo(c.points[i].x,c.points[i].y); ctx.stroke(); } break;
+        case "drawCurve": ctx.strokeStyle=fg; ctx.lineWidth=2; ctx.beginPath(); ctx.moveTo(c.startX,c.startY);
+          if(c.controlX2!=null) ctx.bezierCurveTo(c.controlX1,c.controlY1,c.controlX2,c.controlY2,c.endX,c.endY);
+          else ctx.quadraticCurveTo(c.controlX1,c.controlY1,c.endX,c.endY); ctx.stroke(); break;
+        case "drawRectangle": shape(ctx,fg,bg,c.fillMode,()=>ctx.rect(c.x,c.y,c.width,c.height)); break;
+        case "drawRoundedRectangle": shape(ctx,fg,bg,c.fillMode,()=>roundRect(ctx,c.x,c.y,c.width,c.height,c.radius||12)); break;
+        case "drawEllipse": shape(ctx,fg,bg,c.fillMode,()=>ctx.ellipse(c.x+c.width/2,c.y+c.height/2,Math.abs(c.width/2),Math.abs(c.height/2),0,0,7)); break;
+        case "drawPolygon": if(c.points&&c.points.length>=3) shape(ctx,fg,bg,c.fillMode,()=>{
+          ctx.moveTo(c.points[0].x,c.points[0].y); for(let i=1;i<c.points.length;i++) ctx.lineTo(c.points[i].x,c.points[i].y); ctx.closePath(); }); break;
+        case "floodFill": flood(ctx,c.x|0,c.y|0,fg); break;
+        case "placeText": ctx.fillStyle=fg; ctx.font=(c.bold?"bold ":"")+(c.fontSize||16)+"px sans-serif"; ctx.fillText(c.text||"",c.x,c.y); break;
+        case "spray": sprayAt(ctx,fg,c.x,c.y); break;
+        case "sprayPath": (c.points||[]).forEach(p=>sprayAt(ctx,fg,p.x,p.y)); break;
+        case "gradientFill": { const g = c.gradientType==="radial"
+            ? ctx.createRadialGradient((c.x1+c.x2)/2,(c.y1+c.y2)/2,0,(c.x1+c.x2)/2,(c.y1+c.y2)/2,Math.hypot(c.x2-c.x1,c.y2-c.y1)/2)
+            : ctx.createLinearGradient(c.x1,c.y1,c.x2,c.y2);
+          g.addColorStop(0,c.startColor||fg); g.addColorStop(1,c.endColor||bg); ctx.fillStyle=g; ctx.fillRect(0,0,640,480); } break;
+      }
+    }catch(e){}
+  }
+}
+function shape(ctx,fg,bg,mode,path){ ctx.beginPath(); path();
+  if(mode==="filled"){ ctx.fillStyle=fg; ctx.fill(); }
+  else if(mode==="both"){ ctx.fillStyle=bg; ctx.fill(); ctx.strokeStyle=fg; ctx.lineWidth=2; ctx.stroke(); }
+  else { ctx.strokeStyle=fg; ctx.lineWidth=2; ctx.stroke(); } }
+function roundRect(ctx,x,y,w,h,r){ r=Math.min(r,Math.abs(w/2),Math.abs(h/2)); ctx.moveTo(x+r,y);
+  ctx.arcTo(x+w,y,x+w,y+h,r); ctx.arcTo(x+w,y+h,x,y+h,r); ctx.arcTo(x,y+h,x,y,r); ctx.arcTo(x,y,x+w,y,r); ctx.closePath(); }
+function sprayAt(ctx,fg,x,y){ ctx.fillStyle=fg; for(let i=0;i<14;i++){ const a=Math.random()*7,r=Math.random()*10; ctx.fillRect((x+Math.cos(a)*r)|0,(y+Math.sin(a)*r)|0,1,1);} }
+function flood(ctx,x,y,hex){ if(x<0||y<0||x>=640||y>=480) return;
+  const img=ctx.getImageData(0,0,640,480), d=img.data, idx=(y*640+x)*4;
+  const tr=d[idx],tg=d[idx+1],tb=d[idx+2];
+  const m=hex.replace("#",""); const fr=parseInt(m.slice(0,2),16),fgc=parseInt(m.slice(2,4),16),fb=parseInt(m.slice(4,6),16);
+  if(tr===fr&&tg===fgc&&tb===fb) return;
+  const st=[[x,y]]; let guard=0;
+  while(st.length && guard++<300000){ const [cx,cy]=st.pop(); if(cx<0||cy<0||cx>=640||cy>=480) continue;
+    const i=(cy*640+cx)*4; if(d[i]!==tr||d[i+1]!==tg||d[i+2]!==tb) continue;
+    d[i]=fr; d[i+1]=fgc; d[i+2]=fb; d[i+3]=255;
+    st.push([cx+1,cy],[cx-1,cy],[cx,cy+1],[cx,cy-1]); }
+  ctx.putImageData(img,0,0); }
+
+// --- batch loop -----------------------------------------------------------
+const $ = id => document.getElementById(id);
+let done=0, ok=0, fail=0, cmdSum=0, latSum=0, spend=0, lessons=0;
+
+async function run(){
+  stop=false; done=ok=fail=cmdSum=latSum=spend=lessons=0;
+  const model=$("model").value, prompt=$("prompt").value.trim();
+  const total=Math.max(1,Math.min(500,parseInt($("count").value)||1));
+  const cost=parseFloat($("model").selectedOptions[0].dataset.cost||"0");
+  const batchId=crypto.randomUUID();
+  $("grid").innerHTML=""; $("s-total").textContent=total;
+  $("go").disabled=true; $("stop").disabled=false;
+
+  for(let i=0;i<total && !stop;i++){
+    let res;
+    try{
+      const r=await fetch("/api/admin/run?token="+encodeURIComponent(TOKEN),{
+        method:"POST",headers:{"Content-Type":"application/json"},
+        body:JSON.stringify({model,prompt,batchId,index:i,total})});
+      res=await r.json();
+    }catch(e){ res={ok:false,commandCount:0,latencyMs:0,wisdomShown:"",rawError:String(e)}; }
+
+    done++; latSum+=res.latencyMs||0; spend+=cost;
+    if(res.ok){ ok++; cmdSum+=res.commandCount||0; } else { fail++; }
+    if(res.lesson) lessons++;
+
+    // render + upload
+    const cv=document.createElement("canvas"); cv.width=640; cv.height=480;
+    const ctx=cv.getContext("2d"); render(ctx, res.commands);
+    const cell=document.createElement("div"); cell.className="cell"+(res.ok?"":" fail");
+    const thumb=document.createElement("canvas"); thumb.width=160; thumb.height=120;
+    thumb.getContext("2d").drawImage(cv,0,0,160,120);
+    cell.appendChild(thumb);
+    const n=document.createElement("div"); n.className="n"; n.textContent="#"+(i+1); cell.appendChild(n);
+    cell.title=(res.description||res.rawError||"")+" · "+(res.commandCount||0)+" cmds · "+(res.latencyMs||0)+"ms";
+    $("grid").appendChild(cell);
+    if(res.ok && res.generationId){
+      cv.toBlob(b=>{ const fr=new FileReader(); fr.onload=()=>{
+        fetch("/api/mspaint/snapshot",{method:"POST",headers:{"Content-Type":"application/json"},
+          body:JSON.stringify({generationId:res.generationId,image:fr.result})}).catch(()=>{}); };
+        fr.readAsDataURL(b); },"image/png");
+    }
+
+    // metrics
+    $("s-done").textContent=done; $("s-ok").textContent=ok; $("s-fail").textContent=fail;
+    $("s-cmd").textContent=ok?Math.round(cmdSum/ok):0;
+    $("s-lat").textContent=Math.round(latSum/done);
+    $("s-cost").textContent="$"+spend.toFixed(3);
+    $("s-les").textContent=lessons;
+    $("bar").style.width=(done/total*100)+"%";
+    $("wisdom").textContent=(res.wisdomShown&&res.wisdomShown.trim())?res.wisdomShown.trim():"(no accrued wisdom yet — keep going)";
+    if(res.lesson) $("lesson").textContent="cues & strategies: "+(res.lesson.cuesAndStrategies||"—")+"\\n\\ndo differently: "+(res.lesson.doDifferently||"—");
+  }
+  $("go").disabled=false; $("stop").disabled=true;
+}
+$("go").onclick=run;
+$("stop").onclick=()=>{ stop=true; };
+</script>
+</body></html>`;
+}
+
+// --- Wisdom explorer -------------------------------------------------------
+function renderWisdomPage(
+  token: string,
+  categories: { category: string; lessons: number }[],
+  active: string | null,
+  lessons: Record<string, unknown>[],
+  injected: string
+): string {
+  const t = encodeURIComponent(token);
+  const tabs = categories.length
+    ? categories
+        .map(
+          (c) =>
+            `<a class="tab ${c.category === active ? "on" : ""}" href="/api/admin/wisdom?token=${t}&category=${encodeURIComponent(c.category)}">${he(c.category)} <b>${c.lessons}</b></a>`
+        )
+        .join("")
+    : `<span class="muted">No lessons yet — run a batch to accrue some.</span>`;
+
+  const cdtRows = lessons
+    .map(
+      (l) => `<tr>
+      <td>${he(l.difficult_element)}</td>
+      <td>${he(l.why_difficult)}</td>
+      <td>${he(l.common_errors)}</td>
+      <td class="cue">${he(l.cues_and_strategies)}</td>
+    </tr>`
+    )
+    .join("");
+
+  const parseList = (v: unknown): string => {
+    try {
+      const a = JSON.parse(String(v ?? "[]"));
+      return Array.isArray(a) ? a.map((x) => `<li>${he(x)}</li>`).join("") : "";
+    } catch {
+      return "";
+    }
+  };
+  const auditCards = lessons
+    .slice(0, 24)
+    .map(
+      (l) => `<div class="card">
+      <div class="do">→ ${he(l.do_differently) || "—"}</div>
+      ${l.wish_i_knew ? `<div class="wish">💡 ${he(l.wish_i_knew)}</div>` : ""}
+      <div class="cols">
+        <div><b>worked</b><ul>${parseList(l.what_worked)}</ul></div>
+        <div><b>didn't</b><ul>${parseList(l.what_didnt)}</ul></div>
+      </div>
+      ${l.aesthetic_score ? `<div class="score">aesthetic ${he(l.aesthetic_score)}</div>` : ""}
+    </div>`
+    )
+    .join("");
+
+  return `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Wisdom Explorer · MSPaint Admin</title>
+<style>${PAGE_CSS}
+  .flow{display:flex;gap:0;flex-wrap:wrap;align-items:stretch}
+  .step{background:#fff;border:2px outset #fff;padding:8px;min-width:150px;flex:1;position:relative}
+  .step .num{background:#000080;color:#fff;border-radius:50%;width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;font-size:11px;margin-right:4px}
+  .step.hot{background:#ffffcc;outline:3px solid #c00}
+  .step .ttl{font-weight:bold;font-size:12px}
+  .step .d{font-size:11px;color:#333;margin-top:4px}
+  .arrow{display:flex;align-items:center;justify-content:center;font-size:20px;color:#000080;padding:0 4px}
+  .when{background:#ffffcc;border:1px solid #808080;padding:6px;margin-top:8px;font-size:12px}
+  .tabs{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px}
+  .tab{text-decoration:none;background:#c0c0c0;border:2px outset #fff;padding:3px 10px;color:#000}
+  .tab.on{background:#000080;color:#fff;border-style:inset}
+  .tab b{color:#c00}.tab.on b{color:#ff0}
+  .injected{background:#000;color:#3f6;font-family:"Courier New",monospace;font-size:11px;white-space:pre-wrap;padding:10px;border:2px inset #fff;max-height:240px;overflow:auto}
+  table{width:100%;border-collapse:collapse;background:#fff;border:2px inset #fff}
+  th,td{border:1px solid #c0c0c0;padding:5px 7px;font-size:12px;text-align:left;vertical-align:top}
+  th{background:#000080;color:#fff;font-size:11px}
+  td.cue{background:#ffffcc}
+  .cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:8px}
+  .card{background:#fff;border:2px inset #fff;padding:8px;font-size:11px}
+  .card .do{font-weight:bold;color:#000080;margin-bottom:4px}
+  .card .wish{background:#ffffcc;padding:2px 4px;margin-bottom:4px}
+  .card .cols{display:flex;gap:8px}.card .cols>div{flex:1}
+  .card ul{margin:2px 0 0;padding-left:16px}
+  .card .score{margin-top:4px;color:#080}
+  .muted{color:#808080}
+</style></head><body>
+<header>
+  <span>🧠 Wisdom Explorer</span>
+  <a href="/api/admin?token=${t}">← gallery</a>
+  <a href="/api/admin/batch?token=${t}">▶ batch run</a>
+</header>
+
+<div class="win">
+  <h2>How &amp; when wisdom reaches an agent</h2>
+  <div class="flow">
+    <div class="step"><div class="ttl"><span class="num">1</span>Situation assessment</div><div class="d">Classify the prompt → category + which tools matter (ACTA pattern recognition).</div></div>
+    <div class="arrow">▶</div>
+    <div class="step hot"><div class="ttl"><span class="num">2</span>Wisdom recall ★</div><div class="d">Top accrued lessons for that category are injected into the system prompt as <b>"Lessons from artists past"</b> — <i>this</i> is when the agent sees them: before it draws.</div></div>
+    <div class="arrow">▶</div>
+    <div class="step"><div class="ttl"><span class="num">3</span>Mental simulation</div><div class="d">The agent writes an explicit <code>plan</code> before committing commands.</div></div>
+    <div class="arrow">▶</div>
+    <div class="step"><div class="ttl"><span class="num">4</span>Draw</div><div class="d">Emits paint commands that animate on the canvas.</div></div>
+    <div class="arrow">▶</div>
+    <div class="step"><div class="ttl"><span class="num">5</span>Reflect → accrue</div><div class="d">A reflection pass fills a Cognitive Demands Table + Knowledge Audit, stored as a new lesson for step 2 next time.</div></div>
+  </div>
+  <div class="when"><b>When:</b> wisdom is revealed at step 2, once per drawing, injected as plain text into the system prompt. <b>How much:</b> the top 4 lessons for the category, ranked by <code>helpfulness</code> then recency. <b>Where it comes from:</b> step 5 of every prior drawing — by anyone.</div>
+</div>
+
+<div class="win">
+  <h2>Lessons by category</h2>
+  <div class="tabs">${tabs}</div>
+  <h2 style="font-size:12px">Exactly what an agent drawing <code>${he(active || "—")}</code> sees injected right now:</h2>
+  <div class="injected">${injected && injected.trim() ? he(injected.trim()) : "(empty — no accrued wisdom for this category yet)"}</div>
+</div>
+
+<div class="win">
+  <h2>Cognitive Demands Table — ${he(active || "all")} (${lessons.length})</h2>
+  ${lessons.length ? `<table><thead><tr><th>Difficult element</th><th>Why difficult</th><th>Common errors</th><th>Cues &amp; strategies (what an expert does)</th></tr></thead><tbody>${cdtRows}</tbody></table>` : `<p class="muted">No lessons yet.</p>`}
+</div>
+
+<div class="win">
+  <h2>Knowledge Audit</h2>
+  <div class="cards">${auditCards || '<p class="muted">No lessons yet.</p>'}</div>
+</div>
+</body></html>`;
+}

--- a/website-next/functions/api/mspaint/continue.ts
+++ b/website-next/functions/api/mspaint/continue.ts
@@ -8,7 +8,7 @@
 import type { Env } from "../../_lib/env";
 import { getFlags, retrieveWisdom, recordEvent } from "../../_lib/db";
 import { resolveDrawModel, runVision } from "../../_lib/workers-ai";
-import { hasVision } from "../../_lib/models";
+import { hasVision, drawBudget } from "../../_lib/models";
 import { buildContinuePrompt, buildContinueUserContent, extractJson } from "../../_lib/cta";
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
@@ -36,7 +36,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   let ok = true, needsAnotherTurn = false;
   let commands: unknown[] = [];
   try {
-    const text = await runVision(env, buildContinuePrompt(wisdom), buildContinueUserContent(b.prompt, pass), [b.currentImage], 4096, model);
+    const text = await runVision(env, buildContinuePrompt(wisdom), buildContinueUserContent(b.prompt, pass), [b.currentImage], drawBudget(model), model);
     const p = extractJson<{ commands?: unknown[]; needsAnotherTurn?: boolean }>(text);
     if (p && Array.isArray(p.commands)) {
       commands = p.commands;

--- a/website-next/functions/api/mspaint/continue.ts
+++ b/website-next/functions/api/mspaint/continue.ts
@@ -1,0 +1,51 @@
+/**
+ * POST /api/mspaint/continue — agent "another turn" / look-as-you-go for the
+ * public free tier. Gated by the admin `iterative` flag. The client renders the
+ * canvas so far and sends it; a vision model sees it and returns more commands.
+ * Continuation passes don't consume an extra free use (same drawing).
+ */
+
+import type { Env } from "../../_lib/env";
+import { getFlags, retrieveWisdom, recordEvent } from "../../_lib/db";
+import { resolveDrawModel, runVision } from "../../_lib/workers-ai";
+import { hasVision } from "../../_lib/models";
+import { buildContinuePrompt, buildContinueUserContent, extractJson } from "../../_lib/cta";
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  if (!env.AI) return Response.json({ ok: false, error: "AI not configured" }, { status: 200 });
+
+  const flags = await getFlags(env);
+  if (!flags.iterative) return Response.json({ ok: false, disabled: true }, { status: 200 });
+
+  const b = (await request.json()) as {
+    generationId?: string; prompt?: string; category?: string; pass?: number; currentImage?: string;
+  };
+  if (!b.generationId || !b.prompt || !b.currentImage) {
+    return Response.json({ ok: false, error: "generationId, prompt, currentImage required" }, { status: 400 });
+  }
+  const pass = Math.max(1, Number(b.pass) || 1);
+  if (pass >= flags.maxTurns) return Response.json({ ok: false, maxedOut: true }, { status: 200 });
+
+  const model = await resolveDrawModel(env);
+  if (!hasVision(model)) return Response.json({ ok: false, noVision: true }, { status: 200 });
+
+  const wisdom = await retrieveWisdom(env, b.category || "general", 4);
+  await recordEvent(env, { generationId: b.generationId, seq: 10 * pass, phase: "look", type: "own_canvas", data: { pass } }).catch(() => {});
+
+  let ok = true, needsAnotherTurn = false;
+  let commands: unknown[] = [];
+  try {
+    const text = await runVision(env, buildContinuePrompt(wisdom), buildContinueUserContent(b.prompt, pass), [b.currentImage], 4096, model);
+    const p = extractJson<{ commands?: unknown[]; needsAnotherTurn?: boolean }>(text);
+    if (p && Array.isArray(p.commands)) {
+      commands = p.commands;
+      needsAnotherTurn = !!p.needsAnotherTurn;
+    } else ok = false;
+  } catch {
+    ok = false;
+  }
+  await recordEvent(env, { generationId: b.generationId, seq: 10 * pass + 1, phase: "draw", type: "commands", data: { pass, commandCount: commands.length, commands, needsAnotherTurn } }).catch(() => {});
+
+  return Response.json({ ok, commands, needsAnotherTurn, pass });
+};

--- a/website-next/functions/api/mspaint/critique.ts
+++ b/website-next/functions/api/mspaint/critique.ts
@@ -1,0 +1,59 @@
+/**
+ * POST /api/mspaint/critique — vision critique of a finished public drawing.
+ * Gated by the admin `critique` flag. A vision model SEES the rendered image,
+ * scores it, and the elicited lesson is accrued (sawImage = true).
+ */
+
+import type { Env } from "../../_lib/env";
+import { getFlags, recordLesson, recordEvent, updateGenerationFinal, getGeneration } from "../../_lib/db";
+import { runVision } from "../../_lib/workers-ai";
+import { VISION_CRITIC_MODEL } from "../../_lib/models";
+import { CRITIQUE_VISION_SYSTEM, buildCritiqueUserContent, extractJson } from "../../_lib/cta";
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  if (!env.AI || !env.MSPAINT_DB) return Response.json({ ok: false }, { status: 200 });
+
+  const flags = await getFlags(env);
+  if (!flags.critique) return Response.json({ ok: false, disabled: true }, { status: 200 });
+
+  const b = (await request.json()) as {
+    generationId?: string; prompt?: string; image?: string; category?: string;
+    commandCount?: number; passCount?: number;
+  };
+  if (!b.generationId || !b.prompt || !b.image) {
+    return Response.json({ ok: false, error: "generationId, prompt, image required" }, { status: 400 });
+  }
+
+  // Only critique a real generation that exists.
+  const gen = await getGeneration(env, b.generationId);
+  if (!gen) return Response.json({ ok: false, error: "unknown generation" }, { status: 404 });
+  const category = b.category || String(gen.category || "general");
+
+  let critique: Record<string, unknown> | null = null;
+  try {
+    const text = await runVision(env, CRITIQUE_VISION_SYSTEM, buildCritiqueUserContent(b.prompt, b.commandCount || 0), [b.image], 800, VISION_CRITIC_MODEL);
+    critique = extractJson<Record<string, unknown>>(text);
+  } catch {
+    /* best-effort */
+  }
+  if (!critique) return Response.json({ ok: false }, { status: 200 });
+
+  const score = Number(critique.aestheticScore);
+  await recordLesson(env, {
+    id: crypto.randomUUID(), generationId: b.generationId, category,
+    difficultElement: (critique.difficultElement as string) ?? null,
+    whyDifficult: (critique.whyDifficult as string) ?? null,
+    commonErrors: (critique.commonErrors as string) ?? null,
+    cuesAndStrategies: (critique.cuesAndStrategies as string) ?? null,
+    whatWorked: critique.whatWorked, whatDidnt: critique.whatDidnt,
+    wishIKnew: (critique.wishIKnew as string) ?? null, doDifferently: (critique.doDifferently as string) ?? null,
+    toolsNeeded: critique.toolsNeeded, aestheticScore: Number.isFinite(score) ? score : null, sawImage: true,
+  }).catch(() => {});
+  await updateGenerationFinal(env, b.generationId, {
+    passCount: b.passCount, aestheticScore: Number.isFinite(score) ? score : null, critique: JSON.stringify(critique),
+  }).catch(() => {});
+  await recordEvent(env, { generationId: b.generationId, seq: 9999, phase: "critique", type: "vision_critique", data: critique }).catch(() => {});
+
+  return Response.json({ ok: true, critique });
+};

--- a/website-next/functions/api/mspaint/generate.ts
+++ b/website-next/functions/api/mspaint/generate.ts
@@ -18,15 +18,20 @@ import {
   recordGeneration,
   recordLesson,
   retrieveWisdom,
+  getFlags,
+  recordEvent,
+  updateGenerationFinal,
 } from "../../_lib/db";
-import { storePng } from "../../_lib/r2";
+import { storePng, storeDataUrl } from "../../_lib/r2";
 import {
   buildDrawSystemPrompt,
   REFLECTION_SYSTEM_PROMPT,
   buildReflectionUserContent,
   extractJson,
 } from "../../_lib/cta";
-import { runText, classifyPrompt, resolveDrawModel, UTILITY_MODEL } from "../../_lib/workers-ai";
+import { runText, runVision, classifyPrompt, resolveDrawModel, UTILITY_MODEL } from "../../_lib/workers-ai";
+import { hasVision } from "../../_lib/models";
+import { searchReferences } from "../../_lib/references";
 
 const ALLOWED_ANTHROPIC = new Set([
   "claude-haiku-4-5-20251001",
@@ -39,6 +44,7 @@ interface DrawResult {
   plan: unknown;
   description: string;
   commands: unknown[];
+  needsAnotherTurn: boolean;
 }
 
 function jsonResponse(body: unknown, status: number, setCookie?: string): Response {
@@ -53,6 +59,7 @@ function parseDraw(text: string): DrawResult | null {
     plan?: unknown;
     description?: string;
     commands?: unknown[];
+    needsAnotherTurn?: boolean;
   }>(text);
   if (!parsed || !Array.isArray(parsed.commands)) return null;
   return {
@@ -60,6 +67,7 @@ function parseDraw(text: string): DrawResult | null {
     plan: parsed.plan ?? null,
     description: parsed.description || "Drawing",
     commands: parsed.commands,
+    needsAnotherTurn: !!parsed.needsAnotherTurn,
   };
 }
 
@@ -181,10 +189,15 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   const wisdom = await retrieveWisdom(env, category, 4);
   const drawSystem = buildDrawSystemPrompt(wisdom);
 
+  // Public feature flags (admin-controlled) for non-key visitors.
+  const flags = await getFlags(env);
+
   // 3. Draw.
   let draw: DrawResult | null = null;
   let usage: unknown = null;
   let modelUsed = "";
+  const refKeys: string[] = [];
+  let referenceQuery: string | null = null;
   try {
     if (usingOwnKey) {
       modelUsed = body.model && ALLOWED_ANTHROPIC.has(body.model) ? body.model : DEFAULT_ANTHROPIC;
@@ -206,7 +219,24 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         );
       }
       modelUsed = await resolveDrawModel(env);
-      const text = await runText(env, drawSystem, prompt, 4096, modelUsed);
+
+      // Optional: look at reference photos first (admin flag + vision model).
+      const refImages: string[] = [];
+      if (flags.references && hasVision(modelUsed) && env.PEXELS_API_KEY) {
+        const { images, query } = await searchReferences(env, prompt, 1);
+        referenceQuery = query;
+        for (let i = 0; i < images.length; i++) {
+          refImages.push(images[i].dataUrl);
+          const k = await storeDataUrl(env, `drawings/${generationId}/ref${i}.jpg`, images[i].dataUrl);
+          if (k) refKeys.push(k);
+          if (env.MSPAINT_DB)
+            await recordEvent(env, { generationId, seq: 2, phase: "look", type: "reference_image", data: { url: images[i].url, key: k } }).catch(() => {});
+        }
+      }
+
+      const text = refImages.length
+        ? await runVision(env, drawSystem, prompt, refImages, 4096, modelUsed)
+        : await runText(env, drawSystem, prompt, 4096, modelUsed);
       draw = parseDraw(text);
     }
   } catch (e) {
@@ -246,11 +276,12 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
     await recordGeneration(env, {
       id: generationId, userId, identity: id, provider, model: modelUsed,
-      prompt, category, subcategories, recommendedTools,
+      prompt, category, subcategories, recommendedTools, referenceQuery,
       thinking: draw.thinking, plan: draw.plan, description: draw.description,
       commands: draw.commands, commandCount: draw.commands.length,
       canvasBeforeKey, usageTokens: usage, latencyMs, status: "ok",
     }).catch(() => {});
+    if (refKeys.length) await updateGenerationFinal(env, generationId, { referenceKeys: refKeys }).catch(() => {});
 
     // Decrement quota only for the free path.
     if (usingOwnKey) {
@@ -311,7 +342,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       commands: draw.commands,
       recommendedTools,
       classification: { category: category || "general", subcategories },
+      category: category || "general",
       referenceImages: [],
+      needsAnotherTurn: draw.needsAnotherTurn,
+      canDraw: hasVision(modelUsed),
+      flags,
       usage,
       usesRemaining,
       usesLimit: limit,

--- a/website-next/functions/api/mspaint/generate.ts
+++ b/website-next/functions/api/mspaint/generate.ts
@@ -30,7 +30,7 @@ import {
   extractJson,
 } from "../../_lib/cta";
 import { runText, runTextRich, runVisionRich, classifyPrompt, resolveDrawModel, UTILITY_MODEL } from "../../_lib/workers-ai";
-import { hasVision, drawBudget } from "../../_lib/models";
+import { hasVision, drawBudget, isAllowedModel } from "../../_lib/models";
 import { searchReferences } from "../../_lib/references";
 
 const ALLOWED_ANTHROPIC = new Set([
@@ -127,6 +127,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     canvasSnapshot?: string;
     apiKey?: string;
     model?: string;
+    adminToken?: string;
   };
   try {
     body = await request.json();
@@ -140,6 +141,19 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   const userAnthropicKey = body.apiKey?.trim();
   const usingOwnKey = !!userAnthropicKey;
 
+  // Admin unlock: a valid ADMIN_TOKEN (header or body) lets ONLY the operator
+  // draw on the server-side Anthropic key and pick any catalog model, uncounted.
+  // The public NEVER reaches the server key — they get Workers AI free or their
+  // own key. This is the "gate the expensive stuff to me" boundary.
+  const adminToken = (request.headers.get("X-Admin-Token") || body.adminToken || "").trim();
+  const isAdmin = !!env.ADMIN_TOKEN && adminToken === env.ADMIN_TOKEN;
+  const serverKey = isAdmin ? env.ANTHROPIC_API_KEY?.trim() : undefined;
+  // The key used to draw with Claude: the visitor's own, or (admin only) the
+  // server's. Admin draws are uncounted (no free-quota consumption).
+  const anthropicKey = userAnthropicKey || serverKey;
+  const usingAnthropic = !!anthropicKey;
+  const uncounted = usingOwnKey || isAdmin;
+
   // Identify the user (cookie + IP/UA hash). DB is optional — degrade if absent.
   const id = await identify(request, env);
   const cookie = id.isNewCookie ? identityCookie(id.cookieUuid) : undefined;
@@ -152,8 +166,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     userId = r.userId;
     used = r.quota.used;
 
-    // Free path is gated by quota; bring-your-own-key is unlimited.
-    if (!usingOwnKey && r.quota.exceeded) {
+    // Free path is gated by quota; bring-your-own-key and admin are unlimited.
+    if (!uncounted && r.quota.exceeded) {
       return jsonResponse(
         {
           error: `You've used all ${limit} free drawings. Add your own Anthropic API key in Settings for unlimited drawing.`,
@@ -168,7 +182,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   }
 
   const generationId = crypto.randomUUID();
-  const provider = usingOwnKey ? "anthropic" : "cloudflare";
+  const provider = usingOwnKey
+    ? "anthropic"
+    : serverKey
+      ? "anthropic-admin"
+      : "cloudflare";
 
   // 1. Situation assessment (cheap, via Workers AI when available).
   let category: string | null = null;
@@ -202,10 +220,10 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   // reflection pass so the CDM lesson distills real thinking, not a guess.
   let drawReasoning: string | null = null;
   try {
-    if (usingOwnKey) {
+    if (usingAnthropic) {
       modelUsed = body.model && ALLOWED_ANTHROPIC.has(body.model) ? body.model : DEFAULT_ANTHROPIC;
       const r = await drawWithAnthropic(
-        userAnthropicKey!,
+        anthropicKey!,
         modelUsed,
         drawSystem,
         prompt,
@@ -221,7 +239,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
           cookie
         );
       }
-      modelUsed = await resolveDrawModel(env);
+      // Admins may pick any catalog model per-request (frontier models included);
+      // the public gets the configured free-tier model.
+      modelUsed = isAdmin && body.model && isAllowedModel(body.model)
+        ? body.model
+        : await resolveDrawModel(env);
 
       // Optional: look at reference photos first (admin flag + vision model).
       const refImages: string[] = [];
@@ -287,8 +309,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     }).catch(() => {});
     if (refKeys.length) await updateGenerationFinal(env, generationId, { referenceKeys: refKeys }).catch(() => {});
 
-    // Decrement quota only for the free path.
-    if (usingOwnKey) {
+    // Decrement quota only for the free path; own-key and admin are uncounted.
+    if (uncounted) {
       await bumpTotal(env, userId).catch(() => {});
     } else {
       await consumeFreeUse(env, userId).catch(() => {});
@@ -333,7 +355,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     }
   }
 
-  const usesRemaining = usingOwnKey ? null : Math.max(0, limit - used);
+  const usesRemaining = uncounted ? null : Math.max(0, limit - used);
 
   return jsonResponse(
     {
@@ -354,7 +376,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       usage,
       usesRemaining,
       usesLimit: limit,
-      unlimited: usingOwnKey,
+      unlimited: uncounted,
+      admin: isAdmin,
     },
     200,
     cookie

--- a/website-next/functions/api/mspaint/generate.ts
+++ b/website-next/functions/api/mspaint/generate.ts
@@ -26,7 +26,7 @@ import {
   buildReflectionUserContent,
   extractJson,
 } from "../../_lib/cta";
-import { runText, classifyPrompt, cfModel } from "../../_lib/workers-ai";
+import { runText, classifyPrompt, resolveDrawModel, UTILITY_MODEL } from "../../_lib/workers-ai";
 
 const ALLOWED_ANTHROPIC = new Set([
   "claude-haiku-4-5-20251001",
@@ -205,8 +205,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
           cookie
         );
       }
-      modelUsed = cfModel(env);
-      const text = await runText(env, drawSystem, prompt, 4096);
+      modelUsed = await resolveDrawModel(env);
+      const text = await runText(env, drawSystem, prompt, 4096, modelUsed);
       draw = parseDraw(text);
     }
   } catch (e) {
@@ -270,7 +270,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
               env,
               REFLECTION_SYSTEM_PROMPT,
               buildReflectionUserContent(prompt, category, draw!.description, draw!.commands.length),
-              700
+              700,
+              UTILITY_MODEL
             );
             const ref = extractJson<Record<string, unknown>>(text);
             if (!ref) return;

--- a/website-next/functions/api/mspaint/generate.ts
+++ b/website-next/functions/api/mspaint/generate.ts
@@ -29,8 +29,8 @@ import {
   buildReflectionUserContent,
   extractJson,
 } from "../../_lib/cta";
-import { runText, runVision, classifyPrompt, resolveDrawModel, UTILITY_MODEL } from "../../_lib/workers-ai";
-import { hasVision } from "../../_lib/models";
+import { runText, runTextRich, runVisionRich, classifyPrompt, resolveDrawModel, UTILITY_MODEL } from "../../_lib/workers-ai";
+import { hasVision, drawBudget } from "../../_lib/models";
 import { searchReferences } from "../../_lib/references";
 
 const ALLOWED_ANTHROPIC = new Set([
@@ -198,6 +198,9 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   let modelUsed = "";
   const refKeys: string[] = [];
   let referenceQuery: string | null = null;
+  // The draw agent's concurrent reasoning trace (reasoning models), fed to the
+  // reflection pass so the CDM lesson distills real thinking, not a guess.
+  let drawReasoning: string | null = null;
   try {
     if (usingOwnKey) {
       modelUsed = body.model && ALLOWED_ANTHROPIC.has(body.model) ? body.model : DEFAULT_ANTHROPIC;
@@ -234,10 +237,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         }
       }
 
-      const text = refImages.length
-        ? await runVision(env, drawSystem, prompt, refImages, 4096, modelUsed)
-        : await runText(env, drawSystem, prompt, 4096, modelUsed);
-      draw = parseDraw(text);
+      const result = refImages.length
+        ? await runVisionRich(env, drawSystem, prompt, refImages, drawBudget(modelUsed), modelUsed)
+        : await runTextRich(env, drawSystem, prompt, drawBudget(modelUsed), modelUsed);
+      drawReasoning = result.reasoning;
+      draw = parseDraw(result.text);
     }
   } catch (e) {
     const msg = e instanceof Error ? e.message : "unknown";
@@ -300,7 +304,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
             const text = await runText(
               env,
               REFLECTION_SYSTEM_PROMPT,
-              buildReflectionUserContent(prompt, category, draw!.description, draw!.commands.length),
+              buildReflectionUserContent(prompt, category, draw!.description, draw!.commands.length, drawReasoning, draw!.thinking),
               700,
               UTILITY_MODEL
             );

--- a/website-next/functions/api/mspaint/generate.ts
+++ b/website-next/functions/api/mspaint/generate.ts
@@ -1,183 +1,322 @@
 /**
- * Cloudflare Pages Function — MSPaint AI generation proxy.
+ * MSPaint AI generation — free Cloudflare tier + bring-your-own-key, with
+ * usage quota, full logging, and an expertise-accrual reflection loop.
  *
- * Proxies drawing prompts to Anthropic's Claude API.
- * The user provides their own API key from the Settings window.
- * If ANTHROPIC_API_KEY is set as an env var, it serves as fallback.
+ * Flow:
+ *   identify -> quota -> situation assessment -> recall accrued wisdom ->
+ *   draw (Workers AI free, or user's Anthropic key = unlimited) -> log ->
+ *   (background) reflect -> store lesson.
  */
 
-interface Env {
-  ANTHROPIC_API_KEY?: string;
-}
+import type { Env } from "../../_lib/env";
+import { freeLimit } from "../../_lib/env";
+import { identify, identityCookie } from "../../_lib/identity";
+import {
+  getOrCreateUser,
+  consumeFreeUse,
+  bumpTotal,
+  recordGeneration,
+  recordLesson,
+  retrieveWisdom,
+} from "../../_lib/db";
+import { storePng } from "../../_lib/r2";
+import {
+  buildDrawSystemPrompt,
+  REFLECTION_SYSTEM_PROMPT,
+  buildReflectionUserContent,
+  extractJson,
+} from "../../_lib/cta";
+import { runText, classifyPrompt, cfModel } from "../../_lib/workers-ai";
 
-const SYSTEM_PROMPT = `You are an artist working in MS Paint (Windows 3.1 style). You create drawings by emitting a sequence of paint commands in JSON format.
-
-## Canvas
-- Size: 640 x 480 pixels
-- Origin (0,0) is top-left
-- X increases rightward, Y increases downward
-- Background starts as white (#FFFFFF)
-
-## Available Colors (28-color palette)
-Row 1 (dark): #000000, #808080, #800000, #808000, #008000, #008080, #000080, #800080, #008B8B, #556B2F, #8B4513, #483D8B, #4B0082, #191970
-Row 2 (light): #FFFFFF, #C0C0C0, #FF0000, #FFFF00, #00FF00, #00FFFF, #0000FF, #FF00FF, #FFA500, #FFC0CB, #ADD8E6, #90EE90, #E6E6FA, #FFDAB9
-
-## Command Types
-
-### Color Commands
-- \`{ "type": "setForegroundColor", "color": "#RRGGBB" }\`
-- \`{ "type": "setBackgroundColor", "color": "#RRGGBB" }\`
-
-### Drawing Commands
-- \`{ "type": "drawPixel", "x": N, "y": N }\`
-- \`{ "type": "drawLine", "x1": N, "y1": N, "x2": N, "y2": N }\`
-- \`{ "type": "drawFreehand", "points": [{"x": N, "y": N}, ...] }\`
-- \`{ "type": "drawCurve", "startX": N, "startY": N, "endX": N, "endY": N, "controlX1": N, "controlY1": N }\`
-
-### Shape Commands (fillMode: "outline" | "filled" | "both")
-- \`{ "type": "drawRectangle", "x": N, "y": N, "width": N, "height": N, "fillMode": "..." }\`
-- \`{ "type": "drawEllipse", "x": N, "y": N, "width": N, "height": N, "fillMode": "..." }\`
-- \`{ "type": "drawRoundedRectangle", "x": N, "y": N, "width": N, "height": N, "radius": N, "fillMode": "..." }\`
-- \`{ "type": "drawPolygon", "points": [{"x": N, "y": N}, ...], "fillMode": "..." }\`
-
-### Other Commands
-- \`{ "type": "floodFill", "x": N, "y": N }\`
-- \`{ "type": "placeText", "x": N, "y": N, "text": "...", "fontSize": N, "bold": bool, "italic": bool }\`
-- \`{ "type": "spray", "x": N, "y": N, "duration": N }\`
-- \`{ "type": "sprayPath", "points": [{"x": N, "y": N}, ...] }\`
-- \`{ "type": "setSprayDensity", "density": N }\`
-- \`{ "type": "setToolSize", "size": N }\`
-- \`{ "type": "setBrushShape", "shape": "round" | "square" | "slash" | "backslash" }\`
-- \`{ "type": "clearCanvas" }\`
-
-## Response Format
-Return ONLY a JSON object:
-{
-  "thinking": "Your artistic planning process",
-  "description": "Brief description of what you're drawing",
-  "commands": [ ... ]
-}`;
-
-const ALLOWED_MODELS = new Set([
+const ALLOWED_ANTHROPIC = new Set([
   "claude-haiku-4-5-20251001",
   "claude-sonnet-4-20250514",
 ]);
-const DEFAULT_MODEL = "claude-sonnet-4-20250514";
+const DEFAULT_ANTHROPIC = "claude-sonnet-4-20250514";
+
+interface DrawResult {
+  thinking: string | null;
+  plan: unknown;
+  description: string;
+  commands: unknown[];
+}
+
+function jsonResponse(body: unknown, status: number, setCookie?: string): Response {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (setCookie) headers["Set-Cookie"] = setCookie;
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+function parseDraw(text: string): DrawResult | null {
+  const parsed = extractJson<{
+    thinking?: string;
+    plan?: unknown;
+    description?: string;
+    commands?: unknown[];
+  }>(text);
+  if (!parsed || !Array.isArray(parsed.commands)) return null;
+  return {
+    thinking: parsed.thinking ?? null,
+    plan: parsed.plan ?? null,
+    description: parsed.description || "Drawing",
+    commands: parsed.commands,
+  };
+}
+
+async function drawWithAnthropic(
+  apiKey: string,
+  model: string,
+  system: string,
+  prompt: string,
+  canvasSnapshot?: string
+): Promise<{ draw: DrawResult | null; usage: unknown; raw: string }> {
+  const content: Array<Record<string, unknown>> = [];
+  if (canvasSnapshot) {
+    content.push({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+        data: canvasSnapshot.replace(/^data:image\/png;base64,/, ""),
+      },
+    });
+  }
+  content.push({
+    type: "text",
+    text: (canvasSnapshot ? "Current canvas is shown above.\n\n" : "") + prompt,
+  });
+
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 8192,
+      system,
+      messages: [{ role: "user", content }],
+    }),
+  });
+  if (!res.ok) throw new Error(`Claude API error: ${await res.text()}`);
+  const result = (await res.json()) as {
+    content: Array<{ type: string; text?: string }>;
+    usage?: unknown;
+  };
+  const textBlock = result.content.find((b) => b.type === "text");
+  const raw = textBlock?.text || "";
+  return { draw: parseDraw(raw), usage: result.usage ?? null, raw };
+}
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  const started = Date.now();
+
+  let body: {
+    prompt?: string;
+    canvasSnapshot?: string;
+    apiKey?: string;
+    model?: string;
+  };
   try {
-    const body = await context.request.json() as {
-      prompt?: string;
-      canvasSnapshot?: string;
-      apiKey?: string;
-      model?: string;
-    };
-
-    const { prompt, canvasSnapshot, apiKey: userApiKey, model: userModel } = body;
-
-    if (!prompt || typeof prompt !== "string") {
-      return Response.json({ error: "Prompt is required" }, { status: 400 });
-    }
-
-    const apiKey = userApiKey || context.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
-      return Response.json({
-        error: "No Anthropic API key. Add one in Settings or configure ANTHROPIC_API_KEY.",
-      }, { status: 500 });
-    }
-
-    const model = (userModel && ALLOWED_MODELS.has(userModel)) ? userModel : DEFAULT_MODEL;
-
-    // Build message content
-    const content: Array<Record<string, unknown>> = [];
-
-    if (canvasSnapshot) {
-      content.push({
-        type: "image",
-        source: {
-          type: "base64",
-          media_type: "image/png",
-          data: canvasSnapshot.replace(/^data:image\/png;base64,/, ""),
-        },
-      });
-    }
-
-    let textPrompt = "";
-    if (canvasSnapshot) textPrompt += "Current canvas state is shown above.\n\n";
-    textPrompt += prompt;
-    content.push({ type: "text", text: textPrompt });
-
-    // Call Anthropic API directly (no SDK needed in Workers)
-    const anthropicRes = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model,
-        max_tokens: 8192,
-        system: SYSTEM_PROMPT,
-        messages: [{ role: "user", content }],
-      }),
-    });
-
-    if (!anthropicRes.ok) {
-      const errText = await anthropicRes.text();
-      return Response.json(
-        { error: `Claude API error: ${errText}` },
-        { status: anthropicRes.status }
-      );
-    }
-
-    const result = await anthropicRes.json() as {
-      content: Array<{ type: string; text?: string }>;
-      model: string;
-      stop_reason: string;
-      usage: { input_tokens: number; output_tokens: number };
-    };
-
-    const textBlock = result.content.find((b) => b.type === "text");
-    if (!textBlock?.text) {
-      return Response.json({ error: "No text response from Claude" }, { status: 500 });
-    }
-
-    let parsed: { thinking?: string; description?: string; commands?: unknown[] };
-    try {
-      const jsonMatch = textBlock.text.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) throw new Error("No JSON found");
-      parsed = JSON.parse(jsonMatch[0]);
-    } catch {
-      return Response.json(
-        { error: "Failed to parse paint commands", raw: textBlock.text },
-        { status: 500 }
-      );
-    }
-
-    if (!parsed.commands || !Array.isArray(parsed.commands)) {
-      return Response.json({ error: "Invalid response — missing commands array" }, { status: 500 });
-    }
-
-    return Response.json({
-      thinking: parsed.thinking || null,
-      description: parsed.description || "Drawing",
-      commands: parsed.commands,
-      recommendedTools: [],
-      classification: { category: "unknown", subcategories: [] },
-      referenceImages: [],
-      debug: {
-        model: result.model,
-        stopReason: result.stop_reason,
-        referenceSearchQuery: null,
-      },
-      usage: result.usage,
-    });
-  } catch (error) {
-    console.error("[MSPaint generate]", error);
-    return Response.json(
-      { error: `Internal server error: ${error instanceof Error ? error.message : "unknown"}` },
-      { status: 500 }
-    );
+    body = await request.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON body" }, 400);
   }
+
+  const prompt = (body.prompt || "").trim();
+  if (!prompt) return jsonResponse({ error: "Prompt is required" }, 400);
+
+  const userAnthropicKey = body.apiKey?.trim();
+  const usingOwnKey = !!userAnthropicKey;
+
+  // Identify the user (cookie + IP/UA hash). DB is optional — degrade if absent.
+  const id = await identify(request, env);
+  const cookie = id.isNewCookie ? identityCookie(id.cookieUuid) : undefined;
+
+  let userId = id.cookieUuid;
+  let used = 0;
+  const limit = freeLimit(env);
+  if (env.MSPAINT_DB) {
+    const r = await getOrCreateUser(env, id);
+    userId = r.userId;
+    used = r.quota.used;
+
+    // Free path is gated by quota; bring-your-own-key is unlimited.
+    if (!usingOwnKey && r.quota.exceeded) {
+      return jsonResponse(
+        {
+          error: `You've used all ${limit} free drawings. Add your own Anthropic API key in Settings for unlimited drawing.`,
+          quotaExceeded: true,
+          usesRemaining: 0,
+          usesLimit: limit,
+        },
+        402,
+        cookie
+      );
+    }
+  }
+
+  const generationId = crypto.randomUUID();
+  const provider = usingOwnKey ? "anthropic" : "cloudflare";
+
+  // 1. Situation assessment (cheap, via Workers AI when available).
+  let category: string | null = null;
+  let subcategories: string[] = [];
+  let recommendedTools: string[] = [];
+  if (env.AI) {
+    try {
+      const c = await classifyPrompt(env, prompt);
+      category = c.category;
+      subcategories = c.subcategories;
+      recommendedTools = c.tools;
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  // 2. Recall accrued wisdom for this category (ShadowBox feedback loop).
+  const wisdom = await retrieveWisdom(env, category, 4);
+  const drawSystem = buildDrawSystemPrompt(wisdom);
+
+  // 3. Draw.
+  let draw: DrawResult | null = null;
+  let usage: unknown = null;
+  let modelUsed = "";
+  try {
+    if (usingOwnKey) {
+      modelUsed = body.model && ALLOWED_ANTHROPIC.has(body.model) ? body.model : DEFAULT_ANTHROPIC;
+      const r = await drawWithAnthropic(
+        userAnthropicKey!,
+        modelUsed,
+        drawSystem,
+        prompt,
+        body.canvasSnapshot
+      );
+      draw = r.draw;
+      usage = r.usage;
+    } else {
+      if (!env.AI) {
+        return jsonResponse(
+          { error: "Free drawing is not configured on this server. Add your own Anthropic API key in Settings." },
+          500,
+          cookie
+        );
+      }
+      modelUsed = cfModel(env);
+      const text = await runText(env, drawSystem, prompt, 4096);
+      draw = parseDraw(text);
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "unknown";
+    if (env.MSPAINT_DB) {
+      await recordGeneration(env, {
+        id: generationId, userId, identity: id, provider, model: modelUsed,
+        prompt, category, subcategories, recommendedTools,
+        status: "error", error: msg, latencyMs: Date.now() - started,
+      }).catch(() => {});
+    }
+    return jsonResponse({ error: msg }, 502, cookie);
+  }
+
+  if (!draw) {
+    if (env.MSPAINT_DB) {
+      await recordGeneration(env, {
+        id: generationId, userId, identity: id, provider, model: modelUsed,
+        prompt, category, subcategories, recommendedTools,
+        status: "error", error: "Failed to parse paint commands",
+        latencyMs: Date.now() - started,
+      }).catch(() => {});
+    }
+    return jsonResponse({ error: "The model did not return valid paint commands. Try again." }, 502, cookie);
+  }
+
+  const latencyMs = Date.now() - started;
+
+  // 4. Persist (log everything) — best-effort, never blocks the drawing.
+  let canvasBeforeKey: string | null = null;
+  if (env.MSPAINT_DB) {
+    canvasBeforeKey = await storePng(
+      env,
+      `drawings/${generationId}/before.png`,
+      body.canvasSnapshot
+    );
+
+    await recordGeneration(env, {
+      id: generationId, userId, identity: id, provider, model: modelUsed,
+      prompt, category, subcategories, recommendedTools,
+      thinking: draw.thinking, plan: draw.plan, description: draw.description,
+      commands: draw.commands, commandCount: draw.commands.length,
+      canvasBeforeKey, usageTokens: usage, latencyMs, status: "ok",
+    }).catch(() => {});
+
+    // Decrement quota only for the free path.
+    if (usingOwnKey) {
+      await bumpTotal(env, userId).catch(() => {});
+    } else {
+      await consumeFreeUse(env, userId).catch(() => {});
+      used += 1;
+    }
+
+    // 5. Reflection pass — elicit a Cognitive Demands Table + Knowledge Audit
+    //    and store it as a lesson. Runs in the background via waitUntil.
+    if (env.AI) {
+      context.waitUntil(
+        (async () => {
+          try {
+            const text = await runText(
+              env,
+              REFLECTION_SYSTEM_PROMPT,
+              buildReflectionUserContent(prompt, category, draw!.description, draw!.commands.length),
+              700
+            );
+            const ref = extractJson<Record<string, unknown>>(text);
+            if (!ref) return;
+            await recordLesson(env, {
+              id: crypto.randomUUID(),
+              generationId,
+              category,
+              subcategories,
+              difficultElement: (ref.difficultElement as string) ?? null,
+              whyDifficult: (ref.whyDifficult as string) ?? null,
+              commonErrors: (ref.commonErrors as string) ?? null,
+              cuesAndStrategies: (ref.cuesAndStrategies as string) ?? null,
+              whatWorked: ref.whatWorked,
+              whatDidnt: ref.whatDidnt,
+              wishIKnew: (ref.wishIKnew as string) ?? null,
+              doDifferently: (ref.doDifferently as string) ?? null,
+              toolsNeeded: ref.toolsNeeded,
+            });
+          } catch {
+            /* accrual is best-effort */
+          }
+        })()
+      );
+    }
+  }
+
+  const usesRemaining = usingOwnKey ? null : Math.max(0, limit - used);
+
+  return jsonResponse(
+    {
+      generationId,
+      provider,
+      model: modelUsed,
+      thinking: draw.thinking,
+      plan: draw.plan,
+      description: draw.description,
+      commands: draw.commands,
+      recommendedTools,
+      classification: { category: category || "general", subcategories },
+      referenceImages: [],
+      usage,
+      usesRemaining,
+      usesLimit: limit,
+      unlimited: usingOwnKey,
+    },
+    200,
+    cookie
+  );
 };

--- a/website-next/functions/api/mspaint/snapshot.ts
+++ b/website-next/functions/api/mspaint/snapshot.ts
@@ -1,0 +1,53 @@
+/**
+ * POST /api/mspaint/snapshot — attach the final rendered drawing (the true
+ * "output") to a generation after the client finishes playback.
+ *
+ * Body: { generationId: string, image: dataURL-png }
+ */
+
+import type { Env } from "../../_lib/env";
+import { storePng } from "../../_lib/r2";
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  if (!env.MSPAINT_DB || !env.MSPAINT_BUCKET) {
+    return new Response(JSON.stringify({ ok: false }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  let body: { generationId?: string; image?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), { status: 400 });
+  }
+
+  const { generationId, image } = body;
+  if (!generationId || !image) {
+    return new Response(JSON.stringify({ error: "generationId and image required" }), {
+      status: 400,
+    });
+  }
+
+  // Only attach to a row that exists (avoids writing junk keys).
+  const exists = await env.MSPAINT_DB.prepare("SELECT id FROM generations WHERE id = ?")
+    .bind(generationId)
+    .first();
+  if (!exists) {
+    return new Response(JSON.stringify({ error: "Unknown generationId" }), { status: 404 });
+  }
+
+  const key = await storePng(env, `drawings/${generationId}/after.png`, image);
+  if (key) {
+    await env.MSPAINT_DB.prepare("UPDATE generations SET canvas_after_key = ? WHERE id = ?")
+      .bind(key, generationId)
+      .run();
+  }
+
+  return new Response(JSON.stringify({ ok: true, key }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/website-next/functions/api/mspaint/usage.ts
+++ b/website-next/functions/api/mspaint/usage.ts
@@ -1,0 +1,31 @@
+/**
+ * GET /api/mspaint/usage — current free-tier quota for this anonymous user.
+ * Used by the UI to display "X / N free drawings left" on load.
+ */
+
+import type { Env } from "../../_lib/env";
+import { freeLimit } from "../../_lib/env";
+import { identify, identityCookie } from "../../_lib/identity";
+import { readQuota } from "../../_lib/db";
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  const id = await identify(request, env);
+  const cookie = id.isNewCookie ? identityCookie(id.cookieUuid) : undefined;
+  const limit = freeLimit(env);
+
+  let used = 0;
+  if (env.MSPAINT_DB) {
+    const q = await readQuota(env, id);
+    used = q.used;
+  }
+  const remaining = Math.max(0, limit - used);
+
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (cookie) headers["Set-Cookie"] = cookie;
+
+  return new Response(
+    JSON.stringify({ usesRemaining: remaining, usesLimit: limit, used }),
+    { status: 200, headers }
+  );
+};

--- a/website-next/functions/tsconfig.json
+++ b/website-next/functions/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "WebWorker"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/website-next/package-lock.json
+++ b/website-next/package-lock.json
@@ -43,6 +43,7 @@
         "zustand": "^5.0.11"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260617.1",
         "@tailwindcss/postcss": "^4",
         "@types/dompurify": "^3.0.5",
         "@types/js-yaml": "^4.0.9",
@@ -336,6 +337,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260617.1.tgz",
+      "integrity": "sha512-HdbP3CNcdMZBwegitFDjWvzv+6wPkFXvV9gBXMnf6RjV2Cy3W8TJL3IhSEGul0S6F1DHjnucP7lrpIsvkzNEjA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",

--- a/website-next/package.json
+++ b/website-next/package.json
@@ -44,6 +44,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260617.1",
     "@tailwindcss/postcss": "^4",
     "@types/dompurify": "^3.0.5",
     "@types/js-yaml": "^4.0.9",

--- a/website-next/schema.sql
+++ b/website-next/schema.sql
@@ -1,0 +1,79 @@
+-- MS Paint free-tier + expertise-accrual schema (Cloudflare D1)
+-- Database: someclaudeskills-mspaint (2576030c-1019-41df-87c5-1016ef9af4cf)
+--
+-- Apply with:
+--   npx wrangler d1 execute someclaudeskills-mspaint --remote --file=./schema.sql
+--
+-- Design note: the `lessons` table is deliberately shaped as a
+-- Cognitive Demands Table (Militello & Hutton, ACTA) + Knowledge Audit.
+-- Each completed drawing elicits one lesson; lessons are retrieved by
+-- category and re-injected into future agents (a Shadowbox-style
+-- expert-decision feedback loop). This is how the system accrues
+-- painting expertise over time.
+
+-- Anonymous identity + free-tier quota -------------------------------------
+CREATE TABLE IF NOT EXISTS users (
+  id              TEXT PRIMARY KEY,         -- internal id (== cookie_uuid)
+  cookie_uuid     TEXT,                     -- first-party anonymous id
+  ip_ua_hash      TEXT,                     -- sha256(ip + ua + salt) backup signal
+  free_uses_used  INTEGER NOT NULL DEFAULT 0,
+  total_uses      INTEGER NOT NULL DEFAULT 0,
+  first_seen      TEXT NOT NULL,
+  last_seen       TEXT NOT NULL,
+  country         TEXT,
+  user_agent      TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_users_iphash ON users(ip_ua_hash);
+
+-- Every generation ("write") -----------------------------------------------
+CREATE TABLE IF NOT EXISTS generations (
+  id                TEXT PRIMARY KEY,
+  created_at        TEXT NOT NULL,
+  user_id           TEXT,
+  cookie_uuid       TEXT,
+  ip_ua_hash        TEXT,
+  country           TEXT,
+  user_agent        TEXT,
+  provider          TEXT,                   -- 'cloudflare' | 'anthropic'
+  model             TEXT,
+  prompt            TEXT NOT NULL,
+  category          TEXT,                   -- situation assessment (ACTA)
+  subcategories     TEXT,                   -- JSON
+  recommended_tools TEXT,                   -- JSON
+  reference_query   TEXT,
+  thinking          TEXT,                   -- the agent's reasoning
+  plan              TEXT,                   -- mental-simulation plan
+  description       TEXT,
+  commands          TEXT,                   -- JSON array of PaintCommand
+  command_count     INTEGER,
+  canvas_before_key TEXT,                   -- R2 key (snapshot in)
+  canvas_after_key  TEXT,                   -- R2 key (rendered out)
+  usage_tokens      TEXT,                   -- JSON
+  latency_ms        INTEGER,
+  status            TEXT,                   -- 'ok' | 'error' | 'quota_exceeded'
+  error             TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_gen_user ON generations(user_id);
+CREATE INDEX IF NOT EXISTS idx_gen_created ON generations(created_at);
+CREATE INDEX IF NOT EXISTS idx_gen_category ON generations(category);
+
+-- Accrued expertise: Cognitive Demands Table + Knowledge Audit -------------
+CREATE TABLE IF NOT EXISTS lessons (
+  id                  TEXT PRIMARY KEY,
+  generation_id       TEXT,
+  created_at          TEXT NOT NULL,
+  category            TEXT,
+  subcategories       TEXT,                 -- JSON
+  difficult_element   TEXT,                 -- CDT: the cognitively hard part
+  why_difficult       TEXT,                 -- CDT
+  common_errors       TEXT,                 -- CDT
+  cues_and_strategies TEXT,                 -- CDT: how an expert handles it
+  what_worked         TEXT,                 -- JSON list (Knowledge Audit)
+  what_didnt          TEXT,                 -- JSON list
+  wish_i_knew         TEXT,
+  do_differently      TEXT,
+  tools_needed        TEXT,                 -- JSON list
+  aesthetic_score     REAL,
+  helpfulness         INTEGER NOT NULL DEFAULT 0   -- ranking for re-injection
+);
+CREATE INDEX IF NOT EXISTS idx_lessons_category ON lessons(category);

--- a/website-next/schema.sql
+++ b/website-next/schema.sql
@@ -59,7 +59,11 @@ CREATE TABLE IF NOT EXISTS generations (
   latency_ms        INTEGER,
   status            TEXT,                   -- 'ok' | 'error' | 'quota_exceeded'
   error             TEXT,
-  batch_id          TEXT                    -- admin soak-test batch id (nullable)
+  batch_id          TEXT,                   -- admin soak-test batch id (nullable)
+  pass_count        INTEGER,                -- number of draw turns (look-as-you-go)
+  reference_keys    TEXT,                   -- JSON of R2 keys for reference photos
+  aesthetic_score   REAL,                   -- vision critique score (1-5)
+  critique          TEXT                    -- JSON of the vision critique
 );
 CREATE INDEX IF NOT EXISTS idx_gen_user ON generations(user_id);
 CREATE INDEX IF NOT EXISTS idx_gen_created ON generations(created_at);
@@ -96,6 +100,23 @@ CREATE TABLE IF NOT EXISTS lessons (
   do_differently      TEXT,
   tools_needed        TEXT,                 -- JSON list
   aesthetic_score     REAL,
-  helpfulness         INTEGER NOT NULL DEFAULT 0   -- ranking for re-injection
+  helpfulness         INTEGER NOT NULL DEFAULT 0,  -- ranking for re-injection
+  saw_image           INTEGER NOT NULL DEFAULT 0   -- 1 = vision critique (saw the render)
 );
 CREATE INDEX IF NOT EXISTS idx_lessons_category ON lessons(category);
+
+-- Replay-grade event log (per-step: assess, search, look, plan, draw, critique)
+CREATE TABLE IF NOT EXISTS gen_events (
+  id            TEXT PRIMARY KEY,
+  generation_id TEXT,
+  batch_id      TEXT,
+  seq           INTEGER,
+  ts            TEXT,
+  phase         TEXT,
+  type          TEXT,
+  data          TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_events_gen ON gen_events(generation_id, seq);
+
+-- Runtime config / feature flags -------------------------------------------
+-- (also created above; key/value store. public_features holds the JSON flags.)

--- a/website-next/schema.sql
+++ b/website-next/schema.sql
@@ -58,11 +58,26 @@ CREATE TABLE IF NOT EXISTS generations (
   usage_tokens      TEXT,                   -- JSON
   latency_ms        INTEGER,
   status            TEXT,                   -- 'ok' | 'error' | 'quota_exceeded'
-  error             TEXT
+  error             TEXT,
+  batch_id          TEXT                    -- admin soak-test batch id (nullable)
 );
 CREATE INDEX IF NOT EXISTS idx_gen_user ON generations(user_id);
 CREATE INDEX IF NOT EXISTS idx_gen_created ON generations(created_at);
 CREATE INDEX IF NOT EXISTS idx_gen_category ON generations(category);
+CREATE INDEX IF NOT EXISTS idx_gen_batch ON generations(batch_id);
+
+-- Admin batch runs (premium-model x N soak tests) --------------------------
+CREATE TABLE IF NOT EXISTS batches (
+  id         TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL,
+  model      TEXT,
+  prompt     TEXT,
+  target     INTEGER,
+  completed  INTEGER NOT NULL DEFAULT 0,
+  ok_count   INTEGER NOT NULL DEFAULT 0,
+  fail_count INTEGER NOT NULL DEFAULT 0,
+  status     TEXT
+);
 
 -- Accrued expertise: Cognitive Demands Table + Knowledge Audit -------------
 CREATE TABLE IF NOT EXISTS lessons (

--- a/website-next/schema.sql
+++ b/website-next/schema.sql
@@ -11,6 +11,13 @@
 -- expert-decision feedback loop). This is how the system accrues
 -- painting expertise over time.
 
+-- Runtime config (e.g. the admin-selected free-tier model) -----------------
+CREATE TABLE IF NOT EXISTS config (
+  key        TEXT PRIMARY KEY,
+  value      TEXT,
+  updated_at TEXT
+);
+
 -- Anonymous identity + free-tier quota -------------------------------------
 CREATE TABLE IF NOT EXISTS users (
   id              TEXT PRIMARY KEY,         -- internal id (== cookie_uuid)

--- a/website-next/src/app/how-mspaint-learns/page.tsx
+++ b/website-next/src/app/how-mspaint-learns/page.tsx
@@ -1,0 +1,12 @@
+import { Desktop } from "@/components/desktop/Desktop";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "How MS Paint Learns | Some Claude Skills",
+  description:
+    "How the free MS Paint drawing agent gets smarter over time: a Cognitive Task Analysis loop (ACTA, Critical Decision Method, ShadowBox) where every drawing deposits a reusable lesson for the next agent.",
+};
+
+export default function HowMSPaintLearnsPage() {
+  return <Desktop initialWindow={{ type: "mspaint-wisdom" }} />;
+}

--- a/website-next/src/components/desktop/Desktop.tsx
+++ b/website-next/src/components/desktop/Desktop.tsx
@@ -19,6 +19,7 @@ import {
   openBaitWindow,
   openSkillsBrowserWindow,
   openMediaWindow,
+  openMSPaintWisdomWindow,
   openTutorialsWindow,
   openArtifactsWindow,
   openWelcomeWindow,
@@ -37,6 +38,7 @@ import { SkillsBrowserWindow } from "./SkillsBrowserWindow";
 import { MediaWindow } from "./MediaWindow";
 import { WinampWindow } from "./WinampWindow";
 import { MSPaintWindow } from "./MSPaintWindow";
+import { MSPaintWisdomWindow } from "./MSPaintWisdomWindow";
 import { TutorialsWindow } from "./TutorialsWindow";
 import { ArtifactsWindow } from "./ArtifactsWindow";
 import { Taskbar } from "./Taskbar";
@@ -341,6 +343,7 @@ export function Desktop({
         case "bait":           openBaitWindow();           break;
         case "skills-browser": openSkillsBrowserWindow();  break;
         case "media":          openMediaWindow();          break;
+        case "mspaint-wisdom": openMSPaintWisdomWindow();  break;
         case "tutorials":      openTutorialsWindow();      break;
         case "artifacts":      openArtifactsWindow();      break;
         case "browser":        openBrowserWindow();        break;
@@ -424,6 +427,7 @@ export function Desktop({
         case "media":     return <MediaWindow />;
         case "winamp":    return <WinampWindow />;
         case "mspaint":   return <MSPaintWindow />;
+        case "mspaint-wisdom": return <MSPaintWisdomWindow />;
         case "tutorials": return <TutorialsWindow />;
         case "artifacts": return <ArtifactsWindow />;
         // Content windows

--- a/website-next/src/components/desktop/MSPaintAppContent.tsx
+++ b/website-next/src/components/desktop/MSPaintAppContent.tsx
@@ -67,6 +67,15 @@ export function MSPaintAppContent() {
 
   const currentPromptRef = useRef<string>("");
   const currentGenerationIdRef = useRef<string | null>(null);
+  // Iterative "look as you go" + vision critique (admin-controlled flags)
+  const needsAnotherTurnRef = useRef(false);
+  const canDrawRef = useRef(false);
+  const categoryRef = useRef<string>("general");
+  const passRef = useRef(0);
+  const cumulativeCmdRef = useRef(0);
+  const flagsRef = useRef<{ references: boolean; critique: boolean; iterative: boolean; maxTurns: number }>({
+    references: false, critique: false, iterative: false, maxTurns: 1,
+  });
 
   // Fetch the current free-tier quota on mount (cookie set by the server)
   useEffect(() => {
@@ -130,6 +139,12 @@ export function MSPaintAppContent() {
 
       // Track quota + which generation this is (for the output snapshot upload).
       currentGenerationIdRef.current = data.generationId || null;
+      needsAnotherTurnRef.current = !!data.needsAnotherTurn;
+      canDrawRef.current = !!data.canDraw;
+      categoryRef.current = data.category || "general";
+      passRef.current = 0;
+      cumulativeCmdRef.current = Array.isArray(data.commands) ? data.commands.length : 0;
+      if (data.flags) flagsRef.current = data.flags;
       setUnlimited(!!data.unlimited);
       if (!data.unlimited && typeof data.usesRemaining === "number") {
         setUsesRemaining(data.usesRemaining);
@@ -157,17 +172,71 @@ export function MSPaintAppContent() {
     }
   }, [canvasRef]);
 
-  // When playback finishes, upload the final rendered canvas as the logged
-  // "output" for this generation (best-effort; never disrupts the user).
-  const handlePlaybackComplete = useCallback(() => {
+  // When playback finishes: optionally let the agent take another turn
+  // (look-as-you-go), then upload the final render and (optionally) critique it.
+  const handlePlaybackComplete = useCallback(async () => {
     const genId = currentGenerationIdRef.current;
     if (!genId || !canvasRef) return;
     const image = canvasRef.toDataURL("image/png");
+    const flags = flagsRef.current;
+
+    // 1. Agent-requested continuation ("I want another turn to keep drawing").
+    if (
+      flags.iterative && canDrawRef.current && needsAnotherTurnRef.current &&
+      passRef.current < flags.maxTurns - 1
+    ) {
+      passRef.current += 1;
+      try {
+        const r = await fetch("/api/mspaint/continue", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            generationId: genId,
+            prompt: currentPromptRef.current,
+            category: categoryRef.current,
+            pass: passRef.current,
+            currentImage: image,
+          }),
+        });
+        const d = await r.json();
+        if (d.ok && Array.isArray(d.commands) && d.commands.length) {
+          needsAnotherTurnRef.current = !!d.needsAnotherTurn;
+          cumulativeCmdRef.current += d.commands.length;
+          // Replay the new commands on top of the existing canvas (no clear).
+          setCommands(d.commands);
+          setPlaybackState((p) => ({
+            ...p, totalCommands: d.commands.length, currentCommandIndex: 0,
+            isPlaying: true, isPaused: false,
+          }));
+          return; // loop: this handler fires again when the new pass finishes
+        }
+      } catch {
+        /* fall through to finalize */
+      }
+    }
+
+    // 2. Finalize: store the rendered output.
     fetch("/api/mspaint/snapshot", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ generationId: genId, image }),
     }).catch(() => {});
+
+    // 3. Optional vision critique of the finished drawing.
+    if (flags.critique) {
+      fetch("/api/mspaint/critique", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          generationId: genId,
+          prompt: currentPromptRef.current,
+          category: categoryRef.current,
+          image,
+          commandCount: cumulativeCmdRef.current,
+          passCount: passRef.current + 1,
+        }),
+      }).catch(() => {});
+    }
   }, [canvasRef]);
 
   const handlePlay    = useCallback(() => setPlaybackState(p => ({ ...p, isPlaying: true,  isPaused: false })), []);

--- a/website-next/src/components/desktop/MSPaintAppContent.tsx
+++ b/website-next/src/components/desktop/MSPaintAppContent.tsx
@@ -12,7 +12,7 @@ import { PlaybackControls } from "@/components/mspaint/PlaybackControls/Playback
 import { CommandLog } from "@/components/mspaint/CommandLog/CommandLog";
 import { ReferencePanel, type ReferenceImageData } from "@/components/mspaint/ReferencePanel";
 import { openSettingsWindow, openMSPaintWisdomWindow } from "@/lib/windowHelpers";
-import { LS_KEY_ANTHROPIC, LS_KEY_MODEL, type MsPaintModel } from "@/components/desktop/SettingsWindow";
+import { LS_KEY_ANTHROPIC, LS_KEY_MODEL, LS_KEY_ADMIN, type MsPaintModel } from "@/components/desktop/SettingsWindow";
 import { cn } from "@/lib/utils";
 import type {
   ToolType, FillMode, BrushShape, ToolSize, PaintCommand, PlaybackState,
@@ -121,9 +121,14 @@ export function MSPaintAppContent() {
       const canvasSnapshot = canvasRef?.toDataURL("image/png");
       const userApiKey = localStorage.getItem(LS_KEY_ANTHROPIC) || undefined;
       const userModel   = (localStorage.getItem(LS_KEY_MODEL) as MsPaintModel | null) || undefined;
+      const adminToken  = localStorage.getItem(LS_KEY_ADMIN) || undefined;
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      // Operator unlock: server-side Claude + any model, uncounted. Ignored by
+      // the server unless it matches ADMIN_TOKEN, so it's safe to always send.
+      if (adminToken) headers["X-Admin-Token"] = adminToken;
       const response = await fetch("/api/mspaint/generate", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: JSON.stringify({ prompt, canvasSnapshot, apiKey: userApiKey, model: userModel }),
       });
 

--- a/website-next/src/components/desktop/MSPaintAppContent.tsx
+++ b/website-next/src/components/desktop/MSPaintAppContent.tsx
@@ -60,7 +60,25 @@ export function MSPaintAppContent() {
   const [sessionId, setSessionId] = useState(generateSessionId);
   const [hasApiKey, setHasApiKey] = useState(false);
 
+  // Free-tier quota (Cloudflare-powered drawings before a key is required)
+  const [usesRemaining, setUsesRemaining] = useState<number | null>(null);
+  const [usesLimit, setUsesLimit] = useState<number>(5);
+  const [unlimited, setUnlimited] = useState(false);
+
   const currentPromptRef = useRef<string>("");
+  const currentGenerationIdRef = useRef<string | null>(null);
+
+  // Fetch the current free-tier quota on mount (cookie set by the server)
+  useEffect(() => {
+    fetch("/api/mspaint/usage")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!d) return;
+        setUsesRemaining(d.usesRemaining ?? null);
+        if (typeof d.usesLimit === "number") setUsesLimit(d.usesLimit);
+      })
+      .catch(() => {});
+  }, []);
 
   // Sync API key status from localStorage (re-check when window gains focus)
   useEffect(() => {
@@ -102,7 +120,19 @@ export function MSPaintAppContent() {
 
       const data = await response.json();
       if (!response.ok) {
+        // Quota exhausted — reflect it in the UI before surfacing the message.
+        if (data.quotaExceeded) {
+          setUsesRemaining(0);
+          setUnlimited(false);
+        }
         throw new Error(data.error || `Generate failed: ${response.statusText}`);
+      }
+
+      // Track quota + which generation this is (for the output snapshot upload).
+      currentGenerationIdRef.current = data.generationId || null;
+      setUnlimited(!!data.unlimited);
+      if (!data.unlimited && typeof data.usesRemaining === "number") {
+        setUsesRemaining(data.usesRemaining);
       }
 
       setAiThinking(data.thinking || null);
@@ -125,6 +155,19 @@ export function MSPaintAppContent() {
     } finally {
       setIsGenerating(false);
     }
+  }, [canvasRef]);
+
+  // When playback finishes, upload the final rendered canvas as the logged
+  // "output" for this generation (best-effort; never disrupts the user).
+  const handlePlaybackComplete = useCallback(() => {
+    const genId = currentGenerationIdRef.current;
+    if (!genId || !canvasRef) return;
+    const image = canvasRef.toDataURL("image/png");
+    fetch("/api/mspaint/snapshot", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ generationId: genId, image }),
+    }).catch(() => {});
   }, [canvasRef]);
 
   const handlePlay    = useCallback(() => setPlaybackState(p => ({ ...p, isPlaying: true,  isPaused: false })), []);
@@ -162,6 +205,9 @@ export function MSPaintAppContent() {
         onSubmit={handlePromptSubmit}
         isLoading={isGenerating}
         disabled={playbackState.isPlaying && !playbackState.isPaused}
+        usesRemaining={usesRemaining}
+        usesLimit={usesLimit}
+        unlimited={unlimited || hasApiKey}
       />
 
       {/* API Key status bar */}
@@ -172,9 +218,13 @@ export function MSPaintAppContent() {
       )}>
         <span className={cn(
           "text-[9px] font-[family-name:var(--font-system)] font-bold",
-          hasApiKey ? "text-[var(--color-success)]" : "text-[var(--color-error)]"
+          "text-[var(--color-success)]"
         )}>
-          {hasApiKey ? "API key set — ready to draw" : "No API key — add one in Settings"}
+          {hasApiKey
+            ? "API key set — unlimited drawing"
+            : usesRemaining === 0
+              ? "Free drawings used up — add a key in Settings for unlimited"
+              : "Free AI drawing (Cloudflare) — no key needed"}
         </span>
         <button
           onClick={() => { openSettingsWindow(); setHasApiKey(!!localStorage.getItem(LS_KEY_ANTHROPIC)); }}
@@ -238,7 +288,7 @@ export function MSPaintAppContent() {
               onPlaybackStateChange={setPlaybackState}
               onColorPick={(color) => setForegroundColor(color)}
               onCommandExecuted={handleCommandExecuted}
-              onPlaybackComplete={() => {}}
+              onPlaybackComplete={handlePlaybackComplete}
               clearSignal={clearSignal}
             />
           </div>

--- a/website-next/src/components/desktop/MSPaintAppContent.tsx
+++ b/website-next/src/components/desktop/MSPaintAppContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
-import { Settings } from "lucide-react";
+import { Settings, Sparkles } from "lucide-react";
 import { ToolPalette } from "@/components/mspaint/ToolPalette/ToolPalette";
 import { ColorPalette } from "@/components/mspaint/ColorPalette/ColorPalette";
 import { Canvas } from "@/components/mspaint/Canvas/Canvas";
@@ -11,7 +11,7 @@ import { PromptInput } from "@/components/mspaint/PromptInput/PromptInput";
 import { PlaybackControls } from "@/components/mspaint/PlaybackControls/PlaybackControls";
 import { CommandLog } from "@/components/mspaint/CommandLog/CommandLog";
 import { ReferencePanel, type ReferenceImageData } from "@/components/mspaint/ReferencePanel";
-import { openSettingsWindow } from "@/lib/windowHelpers";
+import { openSettingsWindow, openMSPaintWisdomWindow } from "@/lib/windowHelpers";
 import { LS_KEY_ANTHROPIC, LS_KEY_MODEL, type MsPaintModel } from "@/components/desktop/SettingsWindow";
 import { cn } from "@/lib/utils";
 import type {
@@ -296,9 +296,23 @@ export function MSPaintAppContent() {
               : "Free AI drawing (Cloudflare) — no key needed"}
         </span>
         <button
-          onClick={() => { openSettingsWindow(); setHasApiKey(!!localStorage.getItem(LS_KEY_ANTHROPIC)); }}
+          onClick={openMSPaintWisdomWindow}
+          title="How this drawing agent gets smarter over time"
           className={cn(
             "ml-auto flex items-center gap-1 px-2 py-0.5",
+            "text-[9px] font-[family-name:var(--font-system)] cursor-pointer",
+            "bg-[var(--color-surface-raised)]",
+            "border border-t-[var(--color-border-raised-light)] border-l-[var(--color-border-raised-light)]",
+            "border-b-[var(--color-border-raised-dark)] border-r-[var(--color-border-raised-dark)]"
+          )}
+        >
+          <Sparkles size={10} />
+          How it learns
+        </button>
+        <button
+          onClick={() => { openSettingsWindow(); setHasApiKey(!!localStorage.getItem(LS_KEY_ANTHROPIC)); }}
+          className={cn(
+            "flex items-center gap-1 px-2 py-0.5",
             "text-[9px] font-[family-name:var(--font-system)] cursor-pointer",
             "bg-[var(--color-surface-raised)]",
             "border border-t-[var(--color-border-raised-light)] border-l-[var(--color-border-raised-light)]",

--- a/website-next/src/components/desktop/MSPaintWisdomWindow.tsx
+++ b/website-next/src/components/desktop/MSPaintWisdomWindow.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { Win31Panel, Win31GroupBox, Win31StatusBar, StatusBarSection } from "@/components/win31";
+import {
+  Eye, BookOpen, ListOrdered, Brush, NotebookPen,
+  ArrowRight, Sparkles, Lightbulb, AlertTriangle,
+} from "lucide-react";
+import { openMSPaintWindow } from "@/lib/windowHelpers";
+
+/**
+ * MSPaintWisdomWindow
+ *
+ * Public explainer for the MS Paint expertise-accrual loop: every free drawing
+ * runs a small Cognitive Task Analysis (ACTA / Critical Decision Method /
+ * ShadowBox) and deposits a reusable lesson that the next agent reads first.
+ * Content mirrors the real pipeline in functions/_lib/cta.ts + db.ts.
+ */
+
+const STEPS = [
+  {
+    icon: Eye, accent: "#000080", tag: "1 · Assess",
+    title: "Situation assessment",
+    body: "A fast classifier (≈256 tokens) reads the prompt and decides what kind of subject this is and which paint commands matter — the same first move an expert makes before touching the canvas.",
+  },
+  {
+    icon: BookOpen, accent: "#7c3aed", tag: "2 · Recall",
+    title: "Lessons from artists past",
+    body: "The agent pulls the highest-rated lessons stored by prior agents who drew this category and injects them into its own brief — ShadowBox: learn from the recorded decisions of experts before you.",
+  },
+  {
+    icon: ListOrdered, accent: "#0891b2", tag: "3 · Plan",
+    title: "Mental simulation",
+    body: "Before any command, the agent must commit to an explicit ordered plan ('sky gradient → house mass → shaded side → sun'). Planning is forced, not optional.",
+  },
+  {
+    icon: Brush, accent: "#059669", tag: "4 · Draw",
+    title: "Emit the commands",
+    body: "It blocks in big shapes first, then mid-tones, then details — and may take another look-as-you-go turn rather than stop early on a sparse picture. Vision models can even study reference photos first.",
+  },
+  {
+    icon: NotebookPen, accent: "#d97706", tag: "5 · Reflect",
+    title: "Knowledge elicitation",
+    body: "Afterward a coaching pass runs a Cognitive Demands Table + Knowledge Audit on the result and writes a lesson — the hard part, the cue that works, the one thing to do differently. That lesson becomes step 2 for the next agent.",
+  },
+];
+
+function Eyebrow({ children, color }: { children: React.ReactNode; color: string }) {
+  return (
+    <span
+      className="text-xs font-bold uppercase tracking-[0.12em]"
+      style={{ color }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function MSPaintWisdomWindow() {
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto">
+        {/* Hero */}
+        <div
+          className="px-5 py-5 shrink-0"
+          style={{ background: "linear-gradient(135deg, #000080 0%, #4a0080 45%, #008080 100%)" }}
+        >
+          <div className="flex items-center gap-2 mb-1.5">
+            <Sparkles size={16} className="text-[#FFD700]" />
+            <Eyebrow color="#FFD700">Expertise accrual</Eyebrow>
+          </div>
+          <h1 className="text-white font-[family-name:var(--font-window)] text-2xl font-bold leading-tight">
+            How MS Paint Gets Smarter
+          </h1>
+          <p className="text-white/85 font-[family-name:var(--font-system)] text-base mt-2 max-w-[52ch]">
+            Every free drawing is also a lesson. The agent runs a small cognitive
+            task analysis, then leaves a note for the next agent — so the gallery
+            literally draws better over time, with no model retraining.
+          </p>
+        </div>
+
+        <div className="p-4 space-y-5 font-[family-name:var(--font-system)]">
+          {/* The flywheel */}
+          <section>
+            <Eyebrow color="#000080">The accrual flywheel</Eyebrow>
+            <p className="text-sm text-black/70 mt-1 mb-3 max-w-[60ch]">
+              Five steps, drawn from{" "}
+              <strong>Applied Cognitive Task Analysis (ACTA)</strong>, the{" "}
+              <strong>Critical Decision Method</strong>, and{" "}
+              <strong>ShadowBox</strong>. Step 5 feeds step 2 of the next run.
+            </p>
+
+            <ol className="space-y-2.5">
+              {STEPS.map((s) => {
+                const Icon = s.icon;
+                return (
+                  <li key={s.tag}>
+                    <Win31Panel variant="raised" className="p-2">
+                      <div className="flex gap-3">
+                        <div
+                          className="w-9 h-9 shrink-0 flex items-center justify-center border-2"
+                          style={{ background: s.accent, borderColor: "rgba(0,0,0,0.25)" }}
+                        >
+                          <Icon size={18} className="text-white" />
+                        </div>
+                        <div className="min-w-0">
+                          <div className="flex items-baseline gap-2 flex-wrap">
+                            <Eyebrow color={s.accent}>{s.tag}</Eyebrow>
+                            <span className="text-base font-bold text-black">{s.title}</span>
+                          </div>
+                          <p className="text-sm text-black/80 mt-0.5 leading-snug">{s.body}</p>
+                        </div>
+                      </div>
+                    </Win31Panel>
+                  </li>
+                );
+              })}
+            </ol>
+          </section>
+
+          {/* Worked example: before -> lesson -> after */}
+          <section>
+            <Eyebrow color="#059669">A worked example</Eyebrow>
+            <p className="text-sm text-black/70 mt-1 mb-3 max-w-[60ch]">
+              Two visitors, minutes apart, both type{" "}
+              <code className="bg-black/10 px-1 rounded-sm">a red house with a sun</code>.
+              Here is what the second agent inherits from the first.
+            </p>
+
+            <div className="grid gap-2.5 md:grid-cols-3">
+              {/* Before */}
+              <Win31GroupBox label="Agent #1 — draws blind">
+                <div className="p-1">
+                  <p className="text-sm text-black/80 leading-snug">
+                    Blocks in a flat red square, a triangle roof, a yellow circle
+                    sun. It reads as a child&apos;s drawing: the house floats and
+                    looks 2-D.
+                  </p>
+                  <p className="text-xs text-black/55 mt-2">
+                    Aesthetic score: <strong>2.5 / 5</strong>
+                  </p>
+                </div>
+              </Win31GroupBox>
+
+              {/* Lesson elicited */}
+              <Win31GroupBox label="Lesson elicited (stored in D1)">
+                <div className="p-1 space-y-1.5">
+                  <p className="text-sm">
+                    <Lightbulb size={13} className="inline mr-1 text-[#d97706]" />
+                    <strong>Hard part:</strong> making the house read as solid, not
+                    flat.
+                  </p>
+                  <p className="text-sm">
+                    <span className="font-bold text-[#059669]">What works:</span>{" "}
+                    shade one wall a darker red with a filled polygon to imply a
+                    light direction.
+                  </p>
+                  <p className="text-sm">
+                    <span className="font-bold text-[#000080]">Do differently:</span>{" "}
+                    add a ground line so the house isn&apos;t floating.
+                  </p>
+                </div>
+              </Win31GroupBox>
+
+              {/* After */}
+              <Win31GroupBox label="Agent #2 — reads the lesson first">
+                <div className="p-1">
+                  <p className="text-sm text-black/80 leading-snug">
+                    Draws the front wall, then a darker side wall as a polygon, a
+                    ground line under it, and offsets the sun. The house now sits
+                    in a scene and has volume.
+                  </p>
+                  <p className="text-xs text-black/55 mt-2">
+                    Aesthetic score: <strong>3.8 / 5</strong>
+                  </p>
+                </div>
+              </Win31GroupBox>
+            </div>
+
+            {/* The actual injected briefing */}
+            <div className="mt-3">
+              <Eyebrow color="#000080">What agent #2 actually sees</Eyebrow>
+              <pre
+                className="mt-1.5 p-3 text-sm leading-relaxed overflow-x-auto text-[#00FF00] bg-black border-2"
+                style={{ borderColor: "#000", fontFamily: "var(--font-code, monospace)" }}
+              >{`## Lessons from artists past (apply these)
+Prior agents drawing similar subjects learned:
+1. hard part: making the house read as solid, not flat
+   — what works: shade one wall a darker red (filled polygon)
+   — do differently: add a ground line so it isn't floating`}</pre>
+            </div>
+          </section>
+
+          {/* Why this is honest about its limits — ties to reasoning models */}
+          <section>
+            <Eyebrow color="#d97706">Under the hood: thinking budgets</Eyebrow>
+            <div className="mt-1.5 border-l-4 pl-3 py-1" style={{ borderColor: "#d97706" }}>
+              <p className="text-sm text-black/80 leading-snug max-w-[62ch]">
+                <AlertTriangle size={13} className="inline mr-1 text-[#d97706]" />
+                Each draw call has a token budget that holds{" "}
+                <em>both</em> the agent&apos;s reasoning and the full command list.
+                Plain instruct models spend it all on commands and draw reliably.
+                A <strong>reasoning</strong> model spends much of the budget
+                thinking out loud first — which is exactly the concurrent
+                think-aloud trace that cognitive task analysis prizes. Capturing
+                that trace as primary evidence (instead of asking the model to
+                reconstruct it afterward) is the next upgrade to this flywheel.
+              </p>
+            </div>
+          </section>
+
+          {/* CTA */}
+          <section className="pt-1">
+            <button
+              onClick={openMSPaintWindow}
+              className="inline-flex items-center gap-2 px-4 py-2 text-base font-bold text-white border-2 cursor-pointer"
+              style={{ background: "#000080", borderColor: "#fff #000 #000 #fff" }}
+            >
+              <Brush size={16} />
+              Open MS Paint and add a lesson
+              <ArrowRight size={16} />
+            </button>
+            <p className="text-sm text-black/60 mt-2 max-w-[60ch]">
+              Five free drawings, no API key. Each one teaches the next agent.
+            </p>
+          </section>
+        </div>
+      </div>
+
+      <Win31StatusBar>
+        <StatusBarSection>Assess → Recall → Plan → Draw → Reflect</StatusBarSection>
+        <StatusBarSection>ACTA · CDM · ShadowBox</StatusBarSection>
+      </Win31StatusBar>
+    </div>
+  );
+}

--- a/website-next/src/components/desktop/SettingsWindow.tsx
+++ b/website-next/src/components/desktop/SettingsWindow.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 export const LS_KEY_ANTHROPIC = "mspaint_anthropic_api_key";
 export const LS_KEY_PEXELS    = "mspaint_pexels_api_key";
 export const LS_KEY_MODEL     = "mspaint_model";
+export const LS_KEY_ADMIN     = "mspaint_admin_token";
 
 export type MsPaintModel = "claude-haiku-4-5-20251001" | "claude-sonnet-4-20250514";
 
@@ -25,6 +26,7 @@ export const MODEL_OPTIONS: { value: MsPaintModel; label: string; note: string }
 export function SettingsWindow() {
   const [anthropicKey, setAnthropicKey] = useState("");
   const [pexelsKey, setPexelsKey] = useState("");
+  const [adminToken, setAdminToken] = useState("");
   const [model, setModel] = useState<MsPaintModel>("claude-sonnet-4-20250514");
   const [saved, setSaved] = useState(false);
   const [activeTab, setActiveTab] = useState<"api" | "about">("api");
@@ -32,6 +34,7 @@ export function SettingsWindow() {
   useEffect(() => {
     setAnthropicKey(localStorage.getItem(LS_KEY_ANTHROPIC) || "");
     setPexelsKey(localStorage.getItem(LS_KEY_PEXELS) || "");
+    setAdminToken(localStorage.getItem(LS_KEY_ADMIN) || "");
     const saved = localStorage.getItem(LS_KEY_MODEL) as MsPaintModel | null;
     if (saved && MODEL_OPTIONS.some(o => o.value === saved)) setModel(saved);
   }, []);
@@ -46,6 +49,11 @@ export function SettingsWindow() {
       localStorage.setItem(LS_KEY_PEXELS, pexelsKey.trim());
     } else {
       localStorage.removeItem(LS_KEY_PEXELS);
+    }
+    if (adminToken.trim()) {
+      localStorage.setItem(LS_KEY_ADMIN, adminToken.trim());
+    } else {
+      localStorage.removeItem(LS_KEY_ADMIN);
     }
     localStorage.setItem(LS_KEY_MODEL, model);
     setSaved(true);
@@ -185,6 +193,39 @@ export function SettingsWindow() {
                   "placeholder:text-[var(--color-text-muted)]"
                 )}
               />
+            </div>
+
+            {/* Operator unlock (admin token) */}
+            <div className="space-y-1.5 border-t-2 border-t-[var(--color-border-raised-dark)] pt-3">
+              <label className="block text-[10px] font-bold font-[family-name:var(--font-system)] text-[var(--color-text-primary)]">
+                Operator Unlock (admin only)
+              </label>
+              <p className="text-[9px] font-[family-name:var(--font-system)] text-[var(--color-text-muted)]">
+                The site operator&apos;s ADMIN_TOKEN. Unlocks server-side Claude
+                drawing and any model, uncounted, on the operator&apos;s account.
+                Leave blank — this is not needed for normal use.
+              </p>
+              <input
+                type="password"
+                value={adminToken}
+                onChange={(e) => setAdminToken(e.target.value)}
+                placeholder="(operator only)"
+                className={cn(
+                  "w-full px-2 py-1.5",
+                  "text-[10px] font-[family-name:var(--font-code)]",
+                  "text-[var(--color-text-primary)]",
+                  "bg-[var(--color-surface-inset)]",
+                  "border border-t-[var(--color-border-inset-dark)] border-l-[var(--color-border-inset-dark)]",
+                  "border-b-[var(--color-border-raised-light)] border-r-[var(--color-border-raised-light)]",
+                  "outline-none",
+                  "placeholder:text-[var(--color-text-muted)]"
+                )}
+              />
+              {adminToken && (
+                <p className="text-[9px] text-[var(--color-success)] font-[family-name:var(--font-system)]">
+                  Operator mode armed — drawings use server Claude, uncounted.
+                </p>
+              )}
             </div>
 
             {/* Save button */}

--- a/website-next/src/components/desktop/SettingsWindow.tsx
+++ b/website-next/src/components/desktop/SettingsWindow.tsx
@@ -82,7 +82,13 @@ export function SettingsWindow() {
           <div className="space-y-4">
             <p className="text-[10px] font-[family-name:var(--font-system)] text-[var(--color-text-secondary)] leading-relaxed">
               API keys are stored in your browser (localStorage) and sent with each
-              request. They are never logged or stored on the server.
+              request. Your API key is never logged or stored on the server.
+            </p>
+            <p className="text-[9px] font-[family-name:var(--font-system)] text-[var(--color-text-muted)] leading-relaxed">
+              Note: free AI drawings (without your own key) are powered by Cloudflare
+              and are limited per visitor. To improve the drawing AI, the prompt,
+              the generated drawing, and the resulting image are logged. Add your own
+              key for unlimited drawing.
             </p>
 
             {/* Anthropic key */}

--- a/website-next/src/components/mspaint/Canvas/Canvas.module.css
+++ b/website-next/src/components/mspaint/Canvas/Canvas.module.css
@@ -16,4 +16,9 @@
   display: block;
   cursor: crosshair;
   image-rendering: pixelated;
+  /* Stop the browser hijacking touch as scroll/zoom so drawing works on mobile */
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
 }

--- a/website-next/src/components/mspaint/Canvas/Canvas.tsx
+++ b/website-next/src/components/mspaint/Canvas/Canvas.tsx
@@ -165,15 +165,19 @@ export function Canvas({
     return canvas.getContext('2d');
   }, []);
 
-  // Get mouse position relative to canvas
-  const getMousePos = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+  // Get pointer position relative to canvas, mapped to the canvas's internal
+  // coordinate space (the canvas is often scaled down on mobile, so screen
+  // pixels != canvas pixels — without this scaling, touches land in the wrong spot).
+  const getPointerPos = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
     const canvas = canvasRef.current;
     if (!canvas) return { x: 0, y: 0 };
 
     const rect = canvas.getBoundingClientRect();
+    const scaleX = rect.width ? canvas.width / rect.width : 1;
+    const scaleY = rect.height ? canvas.height / rect.height : 1;
     return {
-      x: Math.floor(e.clientX - rect.left),
-      y: Math.floor(e.clientY - rect.top),
+      x: Math.floor((e.clientX - rect.left) * scaleX),
+      y: Math.floor((e.clientY - rect.top) * scaleY),
     };
   }, []);
 
@@ -566,9 +570,14 @@ export function Canvas({
     }
   }, [getContext, width, height, generateHistoryId]);
 
-  // Mouse event handlers
-  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
-    const pos = getMousePos(e);
+  // Pointer event handlers (unify mouse + touch + pen)
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    // Stop the browser from treating the gesture as scroll/zoom/select on touch.
+    e.preventDefault();
+    // Route all subsequent move/up events for this finger to the canvas.
+    try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* not all browsers */ }
+
+    const pos = getPointerPos(e);
     const ctx = getContext();
     if (!ctx) return;
 
@@ -678,10 +687,11 @@ export function Canvas({
         setGradientStart(pos);
         break;
     }
-  }, [selectedTool, foregroundColor, backgroundColor, toolSize, brushShape, fillMode, getMousePos, getContext, drawPixel, drawBrush, floodFill, pickColor, spray, onColorPick, curvePhase, curveStart, curveEnd, drawCurve, polygonPoints, drawPolygon, zoomLevel, width, height, cloneSource, isSettingCloneSource, stampClone, saveHistoryState]);
+  }, [selectedTool, foregroundColor, backgroundColor, toolSize, brushShape, fillMode, getPointerPos, getContext, drawPixel, drawBrush, floodFill, pickColor, spray, onColorPick, curvePhase, curveStart, curveEnd, drawCurve, polygonPoints, drawPolygon, zoomLevel, width, height, cloneSource, isSettingCloneSource, stampClone, saveHistoryState]);
 
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
-    const pos = getMousePos(e);
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (isDrawing) e.preventDefault();
+    const pos = getPointerPos(e);
     onMouseMove(pos);
 
     if (!isDrawing) return;
@@ -732,12 +742,13 @@ export function Canvas({
     }
 
     setLastPos(pos);
-  }, [isDrawing, selectedTool, foregroundColor, backgroundColor, toolSize, brushShape, lastPos, getMousePos, getContext, drawLine, drawBrush, spray, onMouseMove]);
+  }, [isDrawing, selectedTool, foregroundColor, backgroundColor, toolSize, brushShape, lastPos, getPointerPos, getContext, drawLine, drawBrush, spray, onMouseMove]);
 
-  const handleMouseUp = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+  const handlePointerUp = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* ignore */ }
     if (!isDrawing) return;
 
-    const pos = getMousePos(e);
+    const pos = getPointerPos(e);
     const ctx = getContext();
     if (!ctx) return;
 
@@ -790,9 +801,9 @@ export function Canvas({
     setIsDrawing(false);
     setLastPos(null);
     setShapeStart(null);
-  }, [isDrawing, shapeStart, selectedTool, foregroundColor, backgroundColor, fillMode, toolSize, getMousePos, getContext, drawLine, drawRectangle, drawEllipse, drawRoundedRect, curvePhase, curveStart, drawGradient, gradientStart, saveHistoryState]);
+  }, [isDrawing, shapeStart, selectedTool, foregroundColor, backgroundColor, fillMode, toolSize, getPointerPos, getContext, drawLine, drawRectangle, drawEllipse, drawRoundedRect, curvePhase, curveStart, drawGradient, gradientStart, saveHistoryState]);
 
-  const handleMouseLeave = useCallback(() => {
+  const handlePointerLeave = useCallback(() => {
     onMouseMove(null);
     setIsDrawing(false);
     setLastPos(null);
@@ -1239,10 +1250,11 @@ export function Canvas({
           width={width}
           height={height}
           className={styles.canvas}
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-          onMouseLeave={handleMouseLeave}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          onPointerLeave={handlePointerLeave}
           onContextMenu={(e) => e.preventDefault()}
         />
         {playbackState.ghostCursorPosition && playbackState.isPlaying && (

--- a/website-next/src/components/mspaint/PromptInput/PromptInput.module.css
+++ b/website-next/src/components/mspaint/PromptInput/PromptInput.module.css
@@ -60,6 +60,20 @@
   cursor: default;
 }
 
+.quota {
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  font-family: "MS Sans Serif", "Segoe UI", Tahoma, sans-serif;
+  font-size: 11px;
+  font-weight: bold;
+  color: #000080;
+  background: #C0C0C0;
+  border: 2px solid;
+  border-color: #808080 #FFFFFF #FFFFFF #808080;
+  white-space: nowrap;
+}
+
 .spinner {
   animation: spin 1s linear infinite;
 }

--- a/website-next/src/components/mspaint/PromptInput/PromptInput.tsx
+++ b/website-next/src/components/mspaint/PromptInput/PromptInput.tsx
@@ -8,9 +8,22 @@ interface PromptInputProps {
   onSubmit: (prompt: string) => void;
   isLoading: boolean;
   disabled?: boolean;
+  /** Free Cloudflare-powered drawings remaining (null = unknown/loading). */
+  usesRemaining?: number | null;
+  /** Total free drawings granted per user. */
+  usesLimit?: number;
+  /** True when the user has their own API key (unlimited, no counter). */
+  unlimited?: boolean;
 }
 
-export function PromptInput({ onSubmit, isLoading, disabled }: PromptInputProps) {
+export function PromptInput({
+  onSubmit,
+  isLoading,
+  disabled,
+  usesRemaining,
+  usesLimit = 5,
+  unlimited,
+}: PromptInputProps) {
   const [prompt, setPrompt] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -19,6 +32,8 @@ export function PromptInput({ onSubmit, isLoading, disabled }: PromptInputProps)
       onSubmit(prompt.trim());
     }
   };
+
+  const outOfFree = !unlimited && usesRemaining === 0;
 
   return (
     <form onSubmit={handleSubmit} className={styles.container}>
@@ -32,6 +47,22 @@ export function PromptInput({ onSubmit, isLoading, disabled }: PromptInputProps)
           disabled={isLoading || disabled}
         />
       </div>
+      <span
+        className={styles.quota}
+        title={
+          unlimited
+            ? 'Using your own API key — unlimited drawings'
+            : 'Free AI drawings powered by Cloudflare. Add your own API key in Settings for unlimited.'
+        }
+      >
+        {unlimited
+          ? '∞ unlimited'
+          : usesRemaining === null || usesRemaining === undefined
+            ? `${usesLimit} free`
+            : outOfFree
+              ? '0 left — add key in Settings'
+              : `${usesRemaining} / ${usesLimit} free left`}
+      </span>
       <button
         type="submit"
         className={styles.button}

--- a/website-next/src/lib/windowHelpers.ts
+++ b/website-next/src/lib/windowHelpers.ts
@@ -86,6 +86,17 @@ export function openMSPaintWindow() {
   });
 }
 
+export function openMSPaintWisdomWindow() {
+  const geo = clampGeometry(90, 40, 720, 600);
+  useWindowManager.getState().openWindow({
+    id: "mspaint-wisdom",
+    title: "How MS Paint Learns — README",
+    ...geo,
+    isMinimized: false, isMaximized: false,
+    content: { type: "mspaint-wisdom" },
+  });
+}
+
 export function openMediaWindow() {
   useWindowManager.getState().openWindow({
     id: "media",

--- a/website-next/src/state/windowManager.ts
+++ b/website-next/src/state/windowManager.ts
@@ -14,6 +14,7 @@ export type WindowContentType =
   | { type: "media" }
   | { type: "winamp" }
   | { type: "mspaint" }
+  | { type: "mspaint-wisdom" }
   | { type: "tutorials" }
   | { type: "artifacts" }
   // Misc content windows

--- a/website-next/wrangler.toml
+++ b/website-next/wrangler.toml
@@ -34,5 +34,6 @@ bucket_name = "someclaudeskills-mspaint"
 [vars]
 # Free generations granted per anonymous identity before a key is required.
 FREE_USES_LIMIT = "5"
-# Cheap Workers AI model used for the free tier.
-CF_TEXT_MODEL = "@cf/meta/llama-3.1-8b-instruct"
+# Default free-tier model. Overridable at runtime from the admin tool
+# (/api/admin). Must be one of the ids in functions/_lib/models.ts.
+CF_TEXT_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8"

--- a/website-next/wrangler.toml
+++ b/website-next/wrangler.toml
@@ -1,0 +1,38 @@
+# Cloudflare Pages bindings for the OS2 / MS Paint app.
+#
+# Cloudflare Pages reads this file for Functions bindings. The build output
+# (static export) lives in `out/`. If you deploy via the Pages Git integration,
+# add the same bindings in the dashboard (Settings -> Functions) OR keep this
+# file and deploy with `wrangler pages deploy`.
+#
+# Secrets are NOT stored here. Set them with:
+#   npx wrangler pages secret put ADMIN_TOKEN
+#   npx wrangler pages secret put IDENTITY_SALT
+#   npx wrangler pages secret put ANTHROPIC_API_KEY   # optional fallback
+#   npx wrangler pages secret put PEXELS_API_KEY       # optional references
+
+name = "someclaudeskills-os2"
+pages_build_output_dir = "out"
+compatibility_date = "2024-11-01"
+compatibility_flags = ["nodejs_compat"]
+
+# Cloudflare Workers AI — free-tier drawing brain (cheap Llama model).
+[ai]
+binding = "AI"
+
+# D1 — usage quota, generation log, accrued lessons.
+[[d1_databases]]
+binding = "MSPAINT_DB"
+database_name = "someclaudeskills-mspaint"
+database_id = "2576030c-1019-41df-87c5-1016ef9af4cf"
+
+# R2 — drawing snapshots (before/after PNGs) and reference images.
+[[r2_buckets]]
+binding = "MSPAINT_BUCKET"
+bucket_name = "someclaudeskills-mspaint"
+
+[vars]
+# Free generations granted per anonymous identity before a key is required.
+FREE_USES_LIMIT = "5"
+# Cheap Workers AI model used for the free tier.
+CF_TEXT_MODEL = "@cf/meta/llama-3.1-8b-instruct"


### PR DESCRIPTION
## What this does

Fixes mobile drawing in the OS2 MS Paint app and turns the "Paint it!" feature into a free, instrumented, self-improving drawing service.

### Highlights
- **Mobile fix** — canvas switched from mouse-only to **Pointer Events** (mouse + touch + pen), pointer capture, screen→canvas coordinate scaling, and `touch-action: none`. Taps/drags register correctly on phones.
- **5 free drawings per visitor** via a cheap Cloudflare Workers AI model (emits the same paint-command JSON, so the animation is unchanged). **Bring-your-own Anthropic key = unlimited & uncounted.** Remaining count shows in the prompt bar.
- **Anonymous identity** — first-party cookie UUID + salted `sha256(ip+ua)` backup. (MAC addresses are not available to the web; this is the realistic equivalent.)
- **Everything logged** — D1 (`someclaudeskills-mspaint`) + R2 (`someclaudeskills-mspaint`): prompt, plan, commands, before/after PNGs, model, tokens, latency.
- **Erich-only admin** (`/api/admin`, token-gated): gallery, **model picker with live Cloudflare prices**, **wisdom explorer**, **batch soak-test console**, and **step-by-step replays**.
- **Model catalog (best ↔ worst)** incl. **Kimi K2.7 Code** (frontier 1T, best), GPT-OSS 120B/20B, Llama 4 Scout, QwQ-32B, down to Llama 3.2 1B (cheapest) and Llama 2 7B fp16 (worst value).
- **Expertise accrual (ACTA / Critical Decision Method / ShadowBox)** — each drawing: assess → recall prior lessons (injected as "Lessons from artists past") → plan → draw → reflect → store a Cognitive Demands Table + Knowledge Audit lesson that feeds the next agent.
- **Vision agents** (Kimi / Llama 4 Scout): look at **reference photos** first, **look-as-you-go** ("another turn" so they don't quit early), and **self-critique** the final render (1–5 score). Admin feature flags control what the public gets; the batch console is unrestricted for you.
- **Replays** — `gen_events` logs every step; `/api/admin/replay?id=…` plays the whole process back on a canvas.

Full architecture + design notes: **`website-next/MSPAINT_BACKEND.md`**.

> ⚠️ **Privacy:** the free tier logs visitor prompts + drawings and hashed IPs. The in-app Settings copy discloses this; please add a line to your privacy policy (GDPR/CCPA) before going live.

---

## Already provisioned (live, via the Cloudflare connection)
| Kind | Name | ID |
|---|---|---|
| D1 | `someclaudeskills-mspaint` | `2576030c-1019-41df-87c5-1016ef9af4cf` |
| R2 | `someclaudeskills-mspaint` | — |

Schema is already applied; `website-next/schema.sql` is the version-controlled copy. Bindings are declared in `website-next/wrangler.toml` (`AI`, `MSPAINT_DB`, `MSPAINT_BUCKET`).

---

## 1) Set the secrets (Wrangler)

From `website-next/`:

```bash
cd website-next

# Required — gates the admin console (pick a long random string)
npx wrangler pages secret put ADMIN_TOKEN

# Strongly recommended — salts the IP/UA hash so it can't be reversed
npx wrangler pages secret put IDENTITY_SALT

# Optional — server-side fallback drawing key (users normally bring their own)
npx wrangler pages secret put ANTHROPIC_API_KEY

# Optional — enables "look at references" (Pexels)
npx wrangler pages secret put PEXELS_API_KEY
```

> If the Pages project name differs from `name` in `wrangler.toml`, add `--project-name <your-pages-project>` to each command. List projects with `npx wrangler pages project list`.

Tunables live in `wrangler.toml` `[vars]`: `FREE_USES_LIMIT` (default 5), `CF_TEXT_MODEL` (default `@cf/qwen/qwen3-30b-a3b-fp8`). The active free-tier model is also changeable at runtime from the admin model picker (stored in D1, no redeploy).

### Attach the bindings (if you deploy via the Pages **Git integration**)
`wrangler.toml` is honored automatically by `wrangler pages deploy`. For the Git integration, confirm `name` matches your Pages project, or add the same bindings in the dashboard → Pages project → **Settings → Functions → Bindings**: `AI` (Workers AI), `MSPAINT_DB` → D1, `MSPAINT_BUCKET` → R2.

---

## 2) Build & test

### Local (recommended — exercises the Functions + bindings)
```bash
cd website-next
npm ci
npm run build          # static export -> out/ ; TypeScript must pass

# Run the static site + Pages Functions locally with real bindings.
# --remote uses your live D1/R2/Workers AI (so the AI actually runs).
npx wrangler pages dev out \
  --d1 MSPAINT_DB=someclaudeskills-mspaint \
  --r2 MSPAINT_BUCKET=someclaudeskills-mspaint \
  --ai AI \
  --remote
```
Then:
- Open the app, MS Paint → type a prompt → **Paint it!** Should draw with no API key and decrement "X / 5 free left". On a phone/emulator, verify touch drawing works.
- Admin: `http://localhost:8788/api/admin?token=YOUR_ADMIN_TOKEN` → gallery, model picker (with prices), **Batch run**, **Wisdom explorer**.
- Batch: pick a 👁 vision model (Kimi / Llama 4 Scout), tick **references** + **vision critique**, set a small count (e.g. 5), Run. Click a tile to open its **replay**.

### Typecheck just the Functions
```bash
npx tsc -p functions/tsconfig.json --noEmit
```

### Deploy
```bash
npx wrangler pages deploy out          # or let the Git integration build on merge
# (Re-)apply schema if needed:
npx wrangler d1 execute someclaudeskills-mspaint --remote --file=./schema.sql
```

### Quick API smoke tests
```bash
# remaining free uses
curl -s http://localhost:8788/api/mspaint/usage
# a drawing
curl -s -X POST http://localhost:8788/api/mspaint/generate \
  -H 'content-type: application/json' -d '{"prompt":"a red house"}' | head -c 400
# admin stats
curl -s "http://localhost:8788/api/admin/stats?token=YOUR_ADMIN_TOKEN"
```

---

## 3) Let me (Claude Code) build & test it myself

I run in an ephemeral cloud sandbox. To let me deploy/run Wrangler and exercise the live AI, add these as **environment variables / secrets on the Claude Code web environment** for this repo (Claude Code on the web → environment settings):

| Variable | Why | Where to get it |
|---|---|---|
| `CLOUDFLARE_API_TOKEN` | lets me run `wrangler` (deploy, `pages dev --remote`, `d1 execute`, set secrets) | Cloudflare dashboard → My Profile → API Tokens. Template **"Edit Cloudflare Workers"**, plus **D1 Edit**, **Workers R2 Storage Edit**, **Workers AI Read/Run**, and **Pages Edit**. |
| `CLOUDFLARE_ACCOUNT_ID` | targets the right account | Cloudflare dashboard URL / Workers & Pages overview |
| `ANTHROPIC_API_KEY` | test the bring-your-own-key path (and any Claude-side tooling) | console.anthropic.com |
| `PEXELS_API_KEY` | test the "look at references" feature | pexels.com/api |
| `ADMIN_TOKEN` | so I can hit the admin endpoints in tests | the value you set in step 1 |

Notes:
- **GitHub** access is already wired for this session (I push to `claude/os2-mobile-drawing-tracking-ys9x1n` and manage this PR via the GitHub app) — nothing extra needed. If you'd rather run CI deploys, add `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` as **GitHub repo Actions secrets** and I can wire a deploy workflow.
- With `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` present, I can `npx wrangler pages dev … --remote`, run a small batch, and verify the vision/replay paths against the real models — that's the only way to confirm the Kimi/Scout multimodal request shape and gpt-oss's Responses API, which are currently coded defensively but unverified.
- Treat the Cloudflare token as scoped/rotatable; revoke after if you like.

---

## Caveats
- Vision features only activate when the **active free-tier model is vision-capable** (Kimi / Llama 4 Scout) and (for references) `PEXELS_API_KEY` is set.
- Multimodal request shapes (Kimi/Scout) and the gpt-oss Responses API are coded defensively but not yet runtime-verified — best validated via the batch console after deploy.
- Llama-3.x/Qwen/gpt-oss text models can't see images; the picker marks vision models with 👁.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WnCdxXWWCmbikaSh5oge6

---
_Generated by [Claude Code](https://claude.ai/code/session_017WnCdxXWWCmbikaSh5oge6)_