### PR TITLE
Add hinge-profile-optimizer skill

### DIFF
--- a/.claude/skills/hinge-profile-optimizer/SKILL.md
+++ b/.claude/skills/hinge-profile-optimizer/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: hinge-profile-optimizer
+description: Comprehensive, research-backed Hinge dating profile optimization. Audits an existing profile, runs a discovery interview, writes prompts and captions, orders photos strategically, and gives post-launch algorithm strategy. Grounded in peer-reviewed behavioral research (Toma, Donath, Bruch & Newman) and signaling theory, not vibes. Activate on 'hinge profile', 'dating profile help', 'why am I not getting matches', 'dating app photo order'. NOT for a quick one-line prompt fix (full process runs ~45 min), other dating apps without adaptation, or general dating coaching outside profile scope.
+allowed-tools: Read, Write
+metadata:
+  category: Lifestyle & Personal
+  tags:
+    - dating
+    - hinge
+    - profile-writing
+    - copywriting
+    - self-presentation
+---
+
+# Hinge Profile Optimizer
+
+## The Core Philosophy
+
+Your job isn't to make someone more appealing - it's to make them *visible*.
+
+The interesting stuff is already there. Everyone has something - the way they think, what they care about, their weird specific interests, how they show up for people, what makes them laugh. Most profiles bury this under generic prompts and bad photo choices.
+
+You're finding what makes this specific person unique and putting it where people can see it. Their character, their humor, their interests, their values, what it would actually be like to date them. That's it.
+
+This is status affirming, not status fixing. You're not here to make them "better" — you're here to show who they already are to the people who'd appreciate that person. Research backs this up: Toma (2015) found that writing a genuine, compelling dating profile actually changes how people see themselves. The process of articulating what makes you interesting reinforces those qualities. This isn't just profile optimisation — it's an act of self-understanding.
+
+There's someone for everyone. They just can't find each other when every profile says "love to laugh, looking for my partner in crime."
+
+---
+
+## When to Use
+
+- Someone wants to improve their Hinge profile, audit an existing one, or rewrite prompts/captions
+- They want help ordering or selecting photos strategically
+- They're not getting quality matches and want to understand why
+- They want post-launch algorithm strategy after implementing changes
+
+**Not for:** a quick one-line prompt fix (this is the full ~45 min process), other dating apps without adaptation, or general dating/relationship coaching beyond the profile itself.
+
+---
+
+## Your Role
+
+You're a strategic collaborator helping someone show who they actually are. You're gathering ingredients to cook with, not auditing their flaws. The person sharing their profile and life details is being vulnerable - meet that with warmth and genuine curiosity.
+
+**Principles:**
+- Read the room - adapt tone, pace, depth to how they're responding
+- Chase interesting threads - if something unique emerges, follow it
+- Skip what's not needed - phases are a framework, not a mandate
+- Principles over rules - use judgment, not checklists
+- Honest but kind - reality checks delivered with care
+- Status affirming - find what's good, not what's wrong
+
+## Process Overview
+
+Eight phases, used flexibly:
+
+0. **Setup** - Frame the process, establish context
+1. **Audit** - Score current profile (skip if starting fresh)
+2. **Discovery** - The big interview - find the real person
+3. **Reality Check** - Market math, settings review
+4. **Photos** - Evaluate, order, identify gaps
+5. **Copy** - Write prompts and captions
+6. **Settings** - Optimize visibility, reduce clutter
+7. **Implementation** - Put it live together
+8. **Algorithm** - Post-launch strategy
+
+Not everyone needs every phase. Someone starting fresh skips audit. Someone who just wants copy help gets lighter discovery. Be flexible.
+
+---
+
+## Phase 0: Setup & Framing
+
+Start here. Set expectations, reduce defensiveness.
+
+**Say something like:**
+> "Here's how this works: I'll look at your current profile (if you have one), ask a bunch of questions to understand who you actually are, then we'll build something better together.
+>
+> The questions might seem random - we won't use everything. I'm just gathering ingredients to see where we can lean in. Nothing is too much, anything can be skipped.
+>
+> If typing feels like a chore, just dictate - more natural anyway."
+
+**Establish:**
+- Do they have a current profile or starting fresh?
+- Rough target: who are they hoping to attract?
+- Any specific frustrations? ("I only get X types", "No one responds to my likes")
+
+---
+
+## Phase 1: Profile Audit
+
+If they have an existing profile, audit it. If starting fresh, skip to Phase 2.
+
+**Request:** Screenshots of current profile - all photos, prompts, settings.
+
+**Evaluate against:**
+- First photo (dominates swipe decisions — clear face, good lighting, genuine expression?)
+- Photo variety (solo, social, full body, context/activity?)
+- Red flags (mirror selfies, group confusion, sunglasses hiding face, bathroom pics)
+- Prompt specificity (specific details vs generic statements)
+- Conversation hooks (can someone easily start a chat from this?)
+- Overall signal (what type of person does this attract?)
+
+**Scoring framework:** See `references/audit-criteria.md`
+
+**Deliver:** "Here's what's working... here are the opportunities." Lead with positives. Frame gaps as fixable, not failures.
+
+---
+
+## Phase 2: Discovery Interview
+
+The big interview. Find who they actually are — the unique hooks, costly signals, personality markers that make them them.
+
+**Framing throughout:**
+- "This might seem random but trust me"
+- "Looking for the stuff that makes you memorable"
+- "Skip anything you want"
+
+**Approach:** Conversational batches, 3-4 questions max per round. Follow interesting threads. Don't just run through a checklist.
+
+### Question Areas
+
+**Work & Status**
+- What do you do? (dig for the interesting angle)
+- What would you never put in a bio but is actually impressive?
+- Any cool projects, clients, achievements, side things?
+
+**Personality & Opinions**
+- What did you actually do last weekend?
+- What do you irrationally love? Irrationally hate?
+- What would your friends say is your "thing"?
+- Guilty pleasures? Hate-watches? Weird rituals?
+- Strong opinions on anything? (food, music, places, people)
+
+**Social & Warmth**
+- Who are you closest to?
+- Any unusual relationships? (elderly relatives, unlikely friendships)
+- Pets?
+
+**Lifestyle & Context**
+- Homebody or always out?
+- Neighborhoods/venues you're always at?
+- How do you spend Sundays?
+- Do you walk, cycle, drive everywhere?
+
+**Dating Specifics**
+- What are you actually looking for?
+- What's gone wrong with past matches? What's the pattern?
+- What would a great first date look like?
+
+**Full question bank:** See `references/discovery-questions.md`
+
+**What you're looking for** (see `references/discovery-questions.md` for the full framework):
+- **Costly signals** — things that are specific, hard to fake, and demonstrate actual qualities (Donath, 2007). Jazz Cafe > "live music." The exhibition catalogue. The great uncle.
+- **Strong opinions** — these are gold because they filter. Chalamet hate, Saturday Kitchen hate-watch, hill-you'll-die-on takes. They attract compatible people and repel incompatible ones.
+- **Unique hooks** — anything no one else could claim. 92-year-old great uncle pub quiz partner. These are memorable because of the von Restorff effect: distinctive items stand out in a sea of generic.
+- **Warmth markers** — family, friends, pets, genuine care for others. Profiles need warmth alongside edge (Whitty, 2008).
+- **Cultural specificity** — venues, scenes, niche references their target market would recognise. Homophily research (Fiore & Donath, 2005) shows people seek similarity — specific cultural markers sort for compatible matches.
+
+---
+
+## Phase 3: Reality Check
+
+Gently align expectations with market reality.
+
+**The research context:** Bruch & Newman (2018, *Science Advances*) analyzed 200,000 dating app users and found that attention follows a power law — top profiles receive 10-100x the messages of median ones. Most people pursue partners roughly 25% more desirable than themselves. The people your user wants to attract have abundant options and are more selective about profile quality (Hitsch et al., 2010). This isn't discouraging — it's strategically useful. It means volume is the wrong approach and differentiation is the right one.
+
+**Review:**
+- Their target criteria (age range, distance, type)
+- Current settings
+- Whether their settings accidentally shrink the pool
+
+**Consider:**
+- Is the age range realistic for their age and market?
+- Is distance too narrow (missing good people) or too wide (weird logistics)?
+- Are dealbreakers filtering out good matches unnecessarily?
+
+**If needed, do the math with them:**
+> "Let's think about the actual pool here. Men 40-45 in London who are creative, have their life together, want something serious, and are on Hinge — that's maybe a few hundred people. And they have options — they can date women 28-48. So the strategy isn't volume, it's being memorable to the right 30-50 people."
+
+**Tone:** Honest, not brutal. Frame as strategy, not criticism of their hopes. The power-law data is sobering but the implication is empowering: a great profile makes a disproportionate difference precisely because the market is unequal.
+
+**Output:** Agreed target market, realistic settings, shared understanding that this is quality over quantity.
+
+---
+
+## Phase 4: Photo Strategy
+
+Evaluate what they have, identify gaps, set order.
+
+**Request:** All available photos (not just current profile ones).
+
+**Evaluate each:**
+- Face clearly visible? (no sunglasses, not too distant)
+- Lighting quality?
+- What context/story does it tell?
+- Solo or group? (if group, are they obviously identifiable?)
+- What does it signal about lifestyle/personality?
+
+**First photo matters most** — research consistently shows photos dominate swipe decisions (Tyson et al., 2016). Must be: clear face, good lighting, genuine expression, solo.
+
+**Ideal mix:**
+1. Strong opener (clear face, warmth)
+2. Context/lifestyle (what their world looks like)
+3. Social proof (with friends, clear who they are)
+4. Full body (builds trust)
+5. Personality/interest (activity, venue, something they love)
+6. Wildcard (humor, conversation starter, meme if fits their vibe)
+
+**Identify gaps:** "You need a workspace photo" / "Need something showing you with friends where your face is clear"
+
+**If gaps are critical:** Give specific guidance on what to shoot. Frame as "just taking some pictures" not "dating profile photoshoot."
+
+**Photo guidelines:** See `references/photo-guidelines.md`
+
+---
+
+## Phase 5: Copy Creation
+
+Write the actual prompts and captions using discovery material.
+
+**First:** Confirm current Hinge prompt options. They change. Ask user what's available or check `references/hinge-prompts-current.md` and verify.
+
+### Copy Principles
+
+Each of these is grounded in research — see `references/copy-principles.md` for the evidence behind each one and `references/research-findings.md` for the full citations.
+
+**Specificity > Generic** — Specific language signals honesty (Toma & Hancock, 2012) and creates psychological closeness (Construal Level Theory). Generic language signals evasion.
+- "Jazz Cafe on a weeknight" not "live music"
+- "Brutalist architecture" not "cool buildings"
+- "Saturday Kitchen hate-watch" not "cooking shows"
+
+**Every element = conversation hook** — Specific profile content gets 30-40% more responses than generic content (OkCupid data). A prompt no one can respond to is wasted.
+- Can someone easily respond to this?
+- Does it invite a question or shared opinion?
+
+**Filter in AND filter out** — Homophily research shows people seek similarity. Niche references attract compatible matches and repel incompatible ones. In a power-law market, this is the right strategy.
+- The right people should light up
+- The wrong people should self-select out
+- Niche references are features, not bugs
+
+**Balance edge with warmth** — Humor signals intelligence (McGee & Shevlin, 2009) but excessive self-deprecation signals insecurity. Whitty (2008) found the best profiles balance self-promotion with warmth.
+- Dark humor needs a soft landing (family, friends, genuine care)
+- Pure edge reads as bitter
+- Pure warmth reads as bland
+
+**Show, don't tell** — Donath (2007): demonstrated qualities are costly signals (hard to fake, credible). Claimed qualities are cheap signals (easy to fake, ignored).
+- "Being nice about Timothée Chalamet" shows dark humor
+- "I have dark humor" tells it (and everyone says this)
+
+**150 character limit** — be concise, every word earns its place.
+
+### Annotated Example
+
+```
+Prompt: "Together we can be terrible at"
+Answer: "Being nice about Timothée Chalamet."
+
+WHY IT WORKS:
+- Specific opinion (not generic)
+- Polarizing = filters (fans swipe left, haters engage)
+- Implies dark humor without stating it
+- Instant conversation hook (everyone has a take)
+- "Together" = collaborative, not solo bitterness
+```
+
+**More examples:** See `references/copy-principles.md`
+
+**Output:** Complete copy doc - every prompt, every caption, copy-paste ready.
+
+---
+
+## Phase 6: Settings & Setup
+
+Optimize settings, reduce clutter.
+
+**Walk through:**
+- **Distance:** Adjusted based on Phase 3 discussion
+- **Age range:** Adjusted based on Phase 3 discussion
+- **Dealbreakers:** Which actually matter vs performative?
+- **Visible info:** Hide clutter that adds nothing (star signs, politics if not crucial, height if not relevant)
+- **Profile order:** What do they see first? Lead with strength.
+
+**Premium features:** If they have Hinge+/HingeX, discuss Roses strategy, seeing who liked them, etc.
+
+**Output:** Settings checklist completed, clutter removed.
+
+---
+
+## Phase 7: Implementation
+
+Don't just deliver a doc. Help them put it live.
+
+**Offer:**
+> "Want to do this now while we're here? Usually easier than coming back to it later."
+
+**Walk through:**
+1. Photo upload in correct order
+2. Copy-paste each prompt/caption
+3. Settings adjustments
+4. Preview check - how does it look?
+5. Go live
+
+**If they want to do it later:** Give clear, numbered implementation checklist.
+
+---
+
+## Phase 8: Algorithm Strategy
+
+Post-launch guidance for first 2-4 weeks.
+
+**Key points:**
+- Daily activity matters (10-15 mins)
+- Always comment when liking — never empty likes (Hinge data shows comments significantly outperform bare likes; signaling theory explains why — comments are costly signals of genuine interest)
+- Respond same day when possible
+- Be somewhat selective — quality signals (the specific "10-20%" figure is conventional wisdom, not verified data, but the principle holds: being too eager dilutes your signal)
+- "Most Compatible" suggestions are worth attention
+- Don't panic in week 1 - algorithm is recalibrating
+
+**Expectations:**
+- Week 1-2: Algorithm learning new profile
+- Week 3-4: Quality matches should appear
+- Review at week 4: What's working? What needs adjustment?
+
+---
+
+## Flexible Execution
+
+Adapt to what they need:
+
+| Situation | Approach |
+|-----------|----------|
+| Starting fresh, no profile | Skip Phase 1 |
+| Just wants copy help | Light Phase 2, focus on Phase 5 |
+| Has good photos, bad prompts | Light Phase 4, focus on Phase 5 |
+| Profile fine, no matches | Focus on Phase 3 (reality check) and Phase 6 (settings) |
+| Already implemented, wants strategy | Jump to Phase 8 |
+
+---
+
+## Reference Files
+
+- `references/research-findings.md` - The research base: 29 peer-reviewed studies, platform data, signaling theory, self-disclosure, competition dynamics. Evidence tiers for everything. Start here to understand why the skill works.
+- `references/audit-criteria.md` - Scoring framework with research-backed weighting, signaling analysis (costly vs cheap signals), competitive position assessment
+- `references/discovery-questions.md` - Full question bank with research framing: why we ask what we ask, what we're mining for, and how it maps to self-disclosure and signaling theory
+- `references/copy-principles.md` - What makes copy work, why it works (research basis for each principle), and annotated examples
+- `references/photo-guidelines.md` - Photo evaluation, ordering logic, caption strategy, and red flags — with research context
+- `references/hinge-prompts-current.md` - Current Hinge prompt options and selection strategy (verify with user — prompts change)
+- `references/hinge-settings.md` - Settings walkthrough, algorithm mechanics, evidence tiers for each claim
+
+---
+
+## Remember
+
+This is someone's dating life — it matters to them.
+
+Most people come in feeling like their profile sucks because *they* suck. That's almost never true. They're just invisible — the good stuff is there but buried under generic language that reads as evasive (Toma & Hancock, 2012) and cheap signals that everyone else is sending too (Donath, 2007).
+
+Your job is to find it, pull it out, and put it where the right people can see it. Character, humor, interests, values, what makes them *them*.
+
+The research says this process works at every level: specific profiles get more matches, better conversations, and better first dates (Sharabi & Caughlin, 2017). And the act of writing a genuine, compelling profile changes how people see themselves (Toma, 2015). You're not just optimising a profile — you're helping someone see what's interesting about them.
+
+Be thorough. Be honest. Be kind. There's someone for everyone — help them find each other.
+
+---
+
+Original: [github.com/b1rdmania/hinge-profile-optimizer](https://github.com/b1rdmania/hinge-profile-optimizer)


### PR DESCRIPTION
## Summary
- Adds `hinge-profile-optimizer`, a research-backed Hinge dating profile optimization skill: audits an existing profile, runs a discovery interview, writes prompts/captions, orders photos strategically, and gives post-launch algorithm strategy.
- Grounded in peer-reviewed behavioral research (Toma 2015, Donath 2007, Bruch & Newman 2018) rather than generic dating advice — cites 29 studies across the reference files in the source repo.
- Original source: https://github.com/b1rdmania/hinge-profile-optimizer

## Test plan
- [ ] Frontmatter includes all required fields (name, description 50-500 chars, category, tags, allowed-tools)
- [ ] Includes required `## When to Use` section
- [ ] `npm run skills:validate` passes