### PR TITLE
Add boss-whisperer skill

### DIFF
--- a/.claude/skills/boss-whisperer/DECODE-FORMAT.md
+++ b/.claude/skills/boss-whisperer/DECODE-FORMAT.md
@@ -1,0 +1,64 @@
+# The Decode — output contract
+
+The artifact every run produces. Re-personalise here (real names back in). Bottom-line-up-front,
+reads fast, ends with a move the user can make today. Voice: a sharp friend who happens to
+understand psychology. The diagnosis lands like a deadpan field profile; the advice cashes out
+in a concrete win. Direct, practical, a little cheeky. Never a framework lecture, never clinical.
+
+Use the seven beats below. Drop any beat the input can't support rather than padding it. Mark
+`(inference)` where the evidence is thin; absence of evidence is a gap, not a finding.
+
+---
+
+## 1. The translation
+
+What they are really saying, under the words. The single most useful reframe — the thing the
+user would pay for. "Your boss isn't rejecting your ideas; they're consistency-locked and you
+keep asking them to U-turn in public." Name the Munger tendency or Gottman signal driving it, in
+plain words.
+
+## 2. The power dynamic
+
+Who has leverage, who wants what, and where the tension actually sits. What the boss is
+optimising for under the stated ask — their own boss's approval, a number, control, not looking
+wrong, being liked. Tie it to the incentive.
+
+## 3. The emotional logic
+
+What they may be protecting, avoiding, or trying to control. The fear under the behaviour, and
+how it shows up. **If a transcript was given**, fold in the Gottman read here: the emotional
+weather, which Four Horseman is present (quote the line), and — usefully — which one *the user*
+is feeding without realising.
+
+## 4. The trap
+
+What not to say. The trigger words, the stress window to avoid, the move that reads as a threat.
+Often more valuable than what to do.
+
+## 5. The angle
+
+How to frame the ask so it lands — matched to their decision style and what they reward. Channel
+(written vs meeting), timing, the words that work on this specific person.
+
+## 6. The reply
+
+A direct message the user can send. Written in their voice, not corporate. If a reply isn't what
+the situation needs, give the concrete move instead, landed on the win it buys (the raise, the
+greenlight, the upgrade).
+
+## 7. The next move
+
+What to do if they dodge, delay, or escalate — and what more input (a transcript, a specific
+incident, how they reacted to X) would sharpen the next pass. Always populated: this is what
+makes it iterative.
+
+## Tier 2 enrichment *(Dossier only)*
+
+When public research ran, fold it through the beats above: stated values vs actual incentives,
+status markers, repeated language, ego handles, risk posture, decision triggers, blind spots.
+Every named public fact carries a source, or it doesn't appear.
+
+## Standing footer
+
+Close every decode with: *This is a working model for communicating with a real person, not a
+diagnosis — the goal is to understand and manage up, not to manipulate.*

--- a/.claude/skills/boss-whisperer/FRAMEWORKS.md
+++ b/.claude/skills/boss-whisperer/FRAMEWORKS.md
@@ -1,0 +1,119 @@
+# The decode engine
+
+The psychological frameworks behind The Decode. Harvested from the year-old TheBossWhisperer
+app (`server/openai.ts`) and extended with two further lenses: Munger's
+misjudgment inversion and the Gottman communication read.
+
+Run these on the **tokenised** text (`[BOSS]`, `[COMPANY]`, …). Synthesise — never dump the raw
+frameworks at the user. Use only the layers the input can support. Every claim the evidence
+can't carry is `(inference)` or a gap.
+
+---
+
+## Layer 1 — Munger inversion (the spine)
+
+Charlie Munger, *The Psychology of Human Misjudgment*: humans run on a small set of standard
+misjudgment tendencies. Find the two or three that drive **this** boss, then **invert** — the
+flaw in their reasoning *is* the handle for working with them.
+
+Scan for the tendencies that fit the evidence (this is the working subset, not all 25):
+
+- **Reward/punishment superresponse** — what are they *actually* incentivised on (bonus, their
+  own boss's approval, a board metric)? Behaviour that looks irrational usually serves a hidden
+  incentive. Find the incentive, predict the behaviour.
+- **Liking/loving & disliking/hating** — they over-trust people they like and discount people
+  they don't, regardless of the work. Which camp is the user in, and why?
+- **Consistency & commitment** — once they've said a thing publicly, they defend it past the
+  evidence. Don't make them reverse in public; give them a face-saving off-ramp.
+- **Social proof** — they move when peers/the market/the board move. Frame the ask as what
+  others already do.
+- **Authority-misinfluence** — they defer up and expect deference down. Who is *their*
+  authority figure, and how does that shape what they'll greenlight?
+- **Deprivation superreaction (loss aversion)** — they feel a loss ~2x a gain. Frame proposals
+  as protecting against a loss, not chasing an upside.
+- **Availability / recency** — the last vivid thing dominates their read. Timing of the ask
+  matters as much as the ask.
+- **Stress / first-conclusion bias** — under pressure they lock onto the first answer. Don't
+  bring big asks into their stress windows.
+
+**The inversion move:** name the flaw, then state the *working-with-it* play. Not "they're
+arrogant" but "they're consistency-locked, so never ask them to U-turn in a meeting — give them
+the new data privately and let them arrive at it." The flaw is the instruction.
+
+## Layer 2 — Therapeutic profile (why they tick)
+
+The six-framework engine. Produces mechanism, triggers, and motivators. For each, infer only
+what the evidence supports; rate the numeric scales as rough reads, not measurements.
+
+1. **CBT** — cognitive distortions (catastrophising, black-and-white thinking, mind-reading),
+   the behavioural patterns that reinforce them, what they're averse to, and the healthy coping
+   they already use. → tells you their triggers and what *not* to poke.
+2. **IFS (Internal Family Systems)** — protector parts (how they shield from vulnerability),
+   exile parts (the wound underneath), firefighter parts (the reactive behaviour under stress),
+   and their self-leadership capacity (can they get back to calm-confident?). → tells you what's
+   really happening when they flare.
+3. **Transactional Analysis** — their stroke economy (how they give/withhold recognition), and
+   which ego state dominates: Critical/Nurturing Parent, Adult, or Adaptive/Free Child. → tells
+   you which mode to meet them in. ("They're in Critical Parent right now — don't meet it with
+   Child.")
+4. **Attachment** — secure / anxious / avoidant / disorganised in *work* relationships, plus how
+   it shifts under stress, and how it shows up (trust, micromanagement, withdrawal). → tells you
+   how to build trust and what reads as threat.
+5. **Big Five** — rough 0–100 on Openness, Conscientiousness, Extraversion, Agreeableness,
+   Neuroticism. → calibrates tone, detail level, and pace.
+6. **DISC** — rough 0–100 on Dominance, Influence, Steadiness, Conscientiousness. → the fastest
+   communication-style match: a high-D wants the headline, a high-S wants the reassurance, a
+   high-C wants the evidence.
+
+Output of this layer feeds the manage-up playbook: preferred tone, response style, meeting vs
+email, best timing, trigger words to avoid, words that land.
+
+## Layer 3 — Gottman read (only with a transcript)
+
+Score the *communication*, not the person. From John Gottman's research on what predicts
+relationship breakdown, adapted to the workplace.
+
+- **The Four Horsemen** — flag and quote instances of:
+  - *Criticism* (attacking character, "you always…") vs a specific complaint.
+  - *Contempt* (the strongest signal — sarcasm, condescension, eye-roll-in-text). The most
+    corrosive; if it's present, name it.
+  - *Defensiveness* (counter-attacking, victim-stance, refusing any responsibility).
+  - *Stonewalling* (withdrawal, one-word replies, going silent / ghosting threads).
+- **Bids for connection** — small moves for attention/engagement, and whether the boss turns
+  *toward*, *away*, or *against* them. A boss who consistently turns away from bids is telling
+  you something.
+- **Repair attempts** — does anyone de-escalate, soften, joke, reset? Whether repairs land is
+  more diagnostic than whether conflict happens.
+
+Output: the real emotional weather of the relationship, and where the user is (often
+unknowingly) feeding a horseman they could drop.
+
+---
+
+## Source the methods (link them in the Decode)
+
+Part of the appeal is that this is built on real, named frameworks — not vibes. Cite the two
+headline methods by name in the Decode and link the canonical source so the user can read it:
+
+- **Munger — *The Psychology of Human Misjudgment***. Charlie Munger's speech cataloguing the
+  ~25 standard causes of human misjudgment; definitive text is in *Poor Charlie's Almanack*.
+  Link a stable transcript (e.g. the widely-cited [fs.blog / Farnam Street](https://fs.blog/great-talks/psychology-human-misjudgment/)
+  version) — verify the link resolves before publishing it.
+- **Gottman — the Four Horsemen** (and bids / repair attempts). From John & Julie Gottman's
+  research; canonical write-up at [The Gottman Institute](https://www.gottman.com/blog/the-four-horsemen-recognizing-criticism-contempt-defensiveness-and-stonewalling/) —
+  again, verify before publishing.
+
+Don't fabricate a precise URL. If unsure a deep link resolves, link the institute/book by name
+rather than a guessed slug. The point is to give the user a real source to go read, not to
+look authoritative with a dead link.
+
+## Synthesis rules
+
+- **One read, not three reports.** Weave the layers into a single decode. Reference frameworks
+  naturally if at all ("that's classic consistency-commitment", "they turn away from your bids
+  in writing") — never as headings the user has to wade through.
+- **Mechanism over label.** "They're avoidant-attached, so written praise lands better than a
+  surprise in a meeting" beats "they are avoidant."
+- **Evidence discipline.** Thin input → thin honest decode. Mark `(inference)`. A confident
+  fabrication about a real person the user works with every day is worse than a recorded gap.
+- **Stay on the line.** Every recommendation is "understand and work with", never "exploit".

--- a/.claude/skills/boss-whisperer/SKILL.md
+++ b/.claude/skills/boss-whisperer/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: boss-whisperer
+description: Reverse-engineers your manager from pasted comms — an email thread, Slack history, or a described situation — to show what they actually want, how to manage up, and where the politics sit. Two tiers: a fast anonymised read on what you paste, or an opt-in deep dossier adding public research on the named boss. Gottman communication analysis plus Munger misjudgment inversion. Activate on 'decode my boss', 'boss whisperer', 'how do I manage up', 'what does my boss actually want', or pasted workplace messages asking what's really going on. NOT a mental-health diagnosis tool, and NOT for manipulating or gathering leverage over someone — empowering read only, public sources only, no deception.
+allowed-tools: Read, Write, WebFetch, WebSearch
+metadata:
+  category: Productivity & Meta
+  tags:
+    - management
+    - workplace
+    - psychology
+    - communication
+    - career
+---
+
+# Boss Whisperer
+
+Point a multi-framework profiling engine at your employer. Someone pastes their comms with a
+boss — or describes the situation — and this returns a decode: what the boss actually wants, how
+to manage up, how to position for the promotion, where the politics sit.
+
+The brain is in `FRAMEWORKS.md`; the output contract is in `DECODE-FORMAT.md`. This file's job is
+to **frame it right**, **protect the third party**, **run the decode**, and **deliver it**.
+
+## When to Use
+
+- Someone wants to decode a manager or boss from pasted comms (email thread, Slack history, a performance review, or just a described situation)
+- They want to understand how to manage up, position for a promotion, or read the workplace politics
+- They want a deeper researched profile on a named boss (opt-in, public sources only)
+
+**Not for:** mental-health diagnosis, gathering leverage to manipulate someone, or researching or contacting anyone without consent. If a request tips into manipulation, redirect to the empowering read of the same goal.
+
+## The line (read first, hold throughout)
+
+**Empowering, not manipulative.** ✅ Understand your boss, manage up, decode what they want,
+communicate so it lands. ❌ Game them, exploit them, manufacture leverage, manipulate. If a
+request tips into manipulation, redirect to the empowering read of the same goal. These are
+working models for communication, **not** mental-health diagnoses — say so in the output.
+
+## Privacy by design (per-tier)
+
+**Tier 1** (analysing comms you paste) is fully anonymisable, and you should anonymise it:
+tokenise every identifier before analysis — the boss's name → `[BOSS]`, the company →
+`[COMPANY]`, others → `[COLLEAGUE_1]` etc. Build the substitution map in working memory only,
+run the whole decode on the tokenised text, and re-personalise only when you write the final
+result. Store nothing. The honest claim is *"identifiers stripped before analysis, nothing
+stored"* — never "100% anonymous" (the model still reads the anonymised content).
+
+**Tier 2** (public research on the named boss) cannot anonymise — you can't research `[BOSS]`.
+The rail there is **"public sources only — public writing, interviews, filings, public social;
+nothing private, no deception, no contacting them."** Don't carry the Tier-1 anonymity claim
+into Tier 2; it isn't true there. Get explicit opt-in before researching a named person.
+
+## Levels
+
+| | **Tier 1 — The Read** | **Tier 2 — The Dossier** |
+|---|---|---|
+| Input | the comms you paste | the boss's real name + identifiers |
+| Engine | Gottman + Munger + frameworks on the messages | public-footprint research → fed into the decode |
+| Privacy | anonymisable · store nothing | public sources only · no anonymity |
+| Needs | a Claude/Anthropic key | + web search for the research |
+
+Default: run a Tier-1 read on whatever you're given and offer to go deeper. Never jump to Tier 2
+without opt-in — it researches a real named person.
+
+## Intake — paste everything
+
+There is no length limit, and more is better. Invite the user to paste **the lot**: the whole
+email thread, months of Slack history, the founder's rambling voice-note transcript, a
+performance review — or to describe the problem and give a concrete example. The more it sees,
+the sharper the read. Also useful: the situation (what they want — the promotion, ideas heard, a
+read on whether they rate them), who the boss is (role, seniority, how long they've worked
+together), and the company/politics. Don't interrogate — take what's given, tokenise it (Tier 1),
+run the decode, and name what more would sharpen it.
+
+## The decode
+
+Tier 1 runs on the tokenised text. Tier 2 first runs public research on the named boss. Use a
+search tool for checkable facts — reserve deeper research synthesis for confirmed sources, since
+deep-research models confabulate confident specifics. Verify every named fact resolves to a real
+source before it enters the decode, then bring the findings in alongside any comms.
+
+Load `FRAMEWORKS.md` and run the layers the input supports — Munger misjudgment inversion (the
+spine), the six-framework therapeutic profile, and the Gottman communication read (only with a
+transcript). Synthesise; never lecture. Mark inference as `(inference)`; absence of evidence is
+a gap, not a finding. A thin input gets a thin-but-honest read, never a confident fabrication.
+
+## Output
+
+Write per `DECODE-FORMAT.md`. Re-personalise (real names back) only here. Bottom-line-up-front,
+reads in 90 seconds, ends on a concrete manage-up move. Voice: a sharp friend who happens to
+understand psychology — the diagnosis lands like a deadpan field profile, then cashes out in the
+concrete win (the raise, the greenlight, the upgrade). Plain English, no clinical distance, no
+AI tics. Close with: *this is a working model for communication, not a diagnosis — the goal is to
+manage up, not to manipulate.*
+
+## Running the deep tier yourself
+
+Tier 2 needs a research source — a web-search tool. Without one, Tier 1 still works fully on
+pasted comms. It all runs in your own session, on your own keys (privacy rails per *Privacy by
+design* above).
+
+---
+
+Original: [github.com/b1rdmania/boss-whisperer-skill](https://github.com/b1rdmania/boss-whisperer-skill) — also live at [bosswhisperer.fun](https://bosswhisperer.fun)


### PR DESCRIPTION
## Summary
- Adds `boss-whisperer`: reverse-engineers a manager from pasted comms (email, Slack, described situation) into a read on what they want, how to manage up, and where the politics sit.
- Two tiers: an anonymised fast read on whatever's pasted (tokenises identifiers before analysis, stores nothing), or an opt-in deep dossier adding public research on the named boss (public sources only, no deception).
- Uses Gottman communication analysis + Munger misjudgment inversion, with an explicit "empowering, not manipulative" guardrail baked into the skill itself.
- Includes `FRAMEWORKS.md` and `DECODE-FORMAT.md`, the two files the skill loads at runtime — not just SKILL.md, since those are load-bearing for the skill to actually function.
- Original source: https://github.com/b1rdmania/boss-whisperer-skill — also live at https://bosswhisperer.fun

## Test plan
- [ ] Frontmatter includes all required fields (name, description 50-500 chars, category, tags, allowed-tools)
- [ ] Includes required `## When to Use` section
- [ ] `npm run skills:validate` passes